### PR TITLE
docs(security): Phase13 agentic attack chain library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@
 
 The security boundary has moved from the model to the agentic execution system.
 
+```mermaid
+flowchart TB
+    UP["User prompt"]
+    RD["Retrieved context"]
+    SR["System rules"]
+    AR["<b>Agentic reasoning</b><br/>Goals emerge at runtime;<br/>static review cannot inspect them"]
+    IK["Internal knowledge"]
+    EA["External APIs"]
+    OT["Operational tools"]
+    Risk["<b>Risk accumulation</b><br/>Each step passes a local check;<br/>the composed outcome may exceed approved scope"]
+
+    UP --> AR
+    RD --> AR
+    SR --> AR
+    AR -->|permitted step| IK
+    AR -->|permitted step| EA
+    AR -->|permitted step| OT
+    IK --> Risk
+    EA --> Risk
+    OT --> Risk
+```
+
 Awesome Agentic AI Security is a curated, structured, and continuously updated map of security risks, controls, benchmarks, architectures, and research for agentic, multi-agent, tool-using, self-improving AI systems.
 
 AI systems that act cannot be secured with isolated controls. They need security systems that can see, understand, and govern actions as they unfold. They need controls that observe, interpret, and constrain AI behaviour across prompts, context, tools, memory, credentials, code execution, delegated authority, and multi-agent workflows.
@@ -73,6 +95,42 @@ Prompt injection
 ```
 
 The defensive task is to recognise those paths early, break them deliberately, and make the system's authority and outcomes governable.
+
+```mermaid
+mindmap
+  root((Defence in depth))
+    Environment engineering
+      Refusal tokens
+    Secure protocols
+      Commitments
+      Zero-knowledge proofs
+      Multi-party computation
+    Monitoring and firewalls
+      Layered
+      Dynamic
+    Containment and isolation
+      Sandboxing
+      Trusted execution environments
+      Zero-trust
+    Attribution
+      Provenance
+      Causal inference
+    Cross-cutting
+      Multimodality
+      Chain-of-thought
+      Tool use
+    Adversarial testing
+      Benchmarks
+      Simulations
+    Sociotechnical defences
+      Standards
+      Governance
+      Transparency
+    Trade-offs
+      Security
+      Performance
+      Coordination
+```
 
 ## Security That Governs Action
 

--- a/docs/00-landscape-map.md
+++ b/docs/00-landscape-map.md
@@ -4,6 +4,20 @@ The security boundary for agentic AI is the execution system around the model: t
 
 This landscape map gives readers a common frame before moving into the [threat model](01-threat-model.md). It treats agentic systems as execution environments, not as isolated model endpoints.
 
+The diagram below shows the agentic execution system as five stacked layers, with the control posture wrapping every layer. 
+
+```mermaid
+block-beta
+columns 1
+  Posture["Control posture: Observe → Interpret → Constrain → Audit"]
+  Inputs["Inputs: instructions, retrieved context, memory"]
+  Agent["Agent reasoning"]
+  Action["Action layer: tools, MCP, code, credentials, approvals"]
+  Outcome["Downstream systems and assurance evidence"]
+```
+
+Source: [agentic-execution-landscape.mmd](../visuals/agentic-execution-landscape.mmd).
+
 ## The Protected Object
 
 In a model-centred system, the protected object is often the prompt, the completion, or the data sent to and from the model. In an agentic system, the protected object is broader: it is the system of action that forms around language, tools, state, identity, and authority.

--- a/docs/01-threat-model.md
+++ b/docs/01-threat-model.md
@@ -6,6 +6,31 @@ It is a defensive taxonomy, not an exploit guide. The goal is to help teams ask 
 
 For the broader system map, start with the [landscape map](00-landscape-map.md).
 
+The mindmap below groups the ten failure modes into six families. 
+
+```mermaid
+mindmap
+  root((Failure modes))
+    Influence
+      Prompt injection
+      Goal hijacking
+      Context poisoning
+    Authority
+      Tool misuse
+      Credential misuse
+    State
+      Memory poisoning
+    Capability
+      MCP and extension compromise
+    Propagation
+      Multi-agent propagation
+    Outcome
+      Unsafe autonomous action
+      Monitoring blind spots
+```
+
+Source: [failure-mode-taxonomy.mmd](../visuals/failure-mode-taxonomy.mmd).
+
 ## Scope And Assumptions
 
 This model applies to systems where an AI component can do one or more of the following:
@@ -213,6 +238,25 @@ Control questions:
 - Can reviewers reconstruct the full action path from instruction to outcome?
 - Do evaluations test tools, memory, autonomy, multi-agent communication, and approval gates?
 - Are logs and traces designed for security review, not only debugging?
+
+## Engineering Patterns For Each Failure Mode
+
+Each failure mode above maps to one or more secure engineering patterns. The patterns describe the boundaries, decision points, audit edges, and deny or revise branches that engineers can build to. Use the [secure engineering patterns overview](07-secure-engineering-patterns.md) for the full map; the table below is the quick lookup.
+
+| Failure mode | Primary pattern | Supporting patterns |
+| --- | --- | --- |
+| 1. Prompt and instruction attacks | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | [Memory Security](../patterns/memory-security.md), [Secure MCP](../patterns/secure-mcp.md) |
+| 2. Goal hijacking | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| 3. Tool misuse and unsafe composition | [Secure Tool Calling](../patterns/secure-tool-calling.md) | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 4. Credential and token misuse | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Memory Security](../patterns/memory-security.md) |
+| 5. Context poisoning | [Memory Security](../patterns/memory-security.md) for recall path; planned context-poisoning pattern | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure MCP](../patterns/secure-mcp.md) |
+| 6. Memory poisoning | [Memory Security](../patterns/memory-security.md) | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| 7. MCP, skill, and extension compromise | [Secure MCP](../patterns/secure-mcp.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 8. Multi-agent propagation | Planned multi-agent pattern | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md), [Memory Security](../patterns/memory-security.md) |
+| 9. Unsafe autonomous action | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 10. Monitoring and evaluation blind spots | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) end-to-end trace | Audit evidence sections in all five patterns |
+
+
 
 ## Common Action Paths
 

--- a/docs/02-attack-surfaces.md
+++ b/docs/02-attack-surfaces.md
@@ -19,6 +19,32 @@ An attack surface in an agentic system should be reviewed as a boundary with fou
 
 A surface becomes high risk when untrusted influence can reach meaningful authority without enough interpretation, constraint, or audit evidence.
 
+The mindmap below groups the twelve surfaces into five families: inputs, action, state, governance, and cross-system. 
+
+```mermaid
+mindmap
+  root((Attack surfaces))
+    Inputs
+      Instructions
+      Context and retrieval
+    Action
+      Tools
+      MCP and extensions
+      Code and automation
+      Credentials
+    State
+      Memory
+    Governance
+      Approvals
+      Policy decisions
+      Observability
+    Cross-system
+      Multi-agent
+      Downstream
+```
+
+Source: [surface-boundary-map.mmd](../visuals/surface-boundary-map.mmd).
+
 ## Surface Map
 
 | Surface | What is exposed | Why it matters | Defensive evidence |
@@ -133,6 +159,27 @@ Review these controls:
 3. Link prompts, retrieved context, tool calls, memory changes, approvals, outputs, and downstream actions.
 4. Test multi-step workflows, not only single prompts or final responses.
 5. Use audit evidence for assurance and continuous improvement, not only debugging.
+
+## Engineering Patterns Per Surface
+
+Each surface above maps to one or more secure engineering patterns. The patterns describe the boundaries, decision points, audit edges, and deny or revise branches that engineers can build to. Use the [secure engineering patterns overview](07-secure-engineering-patterns.md) for the full map; the table below is the quick lookup.
+
+| Surface | Pattern(s) that address it |
+| --- | --- |
+| Instruction sources | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| Context and retrieval | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), planned context-poisoning pattern |
+| Tool interfaces | [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Credential boundaries | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Memory and state | [Memory Security](../patterns/memory-security.md) |
+| Code and automation | Planned sandboxing pattern; partially [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| MCP, skills, and extensions | [Secure MCP](../patterns/secure-mcp.md) |
+| Human approvals | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Policy decisions | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| Observability and evaluation | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) end-to-end trace; audit evidence sections in all five patterns |
+| Multi-agent communication | Planned multi-agent pattern |
+| Downstream systems | [Secure Tool Calling](../patterns/secure-tool-calling.md) outcome control, [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+
+
 
 ## Composition Review
 

--- a/docs/03-agentic-attack-chains.md
+++ b/docs/03-agentic-attack-chains.md
@@ -21,7 +21,22 @@ Untrusted language or data
 -> organisational impact
 ```
 
-The reusable Mermaid source for this flow is available in [progressive-breach-model.mmd](../visuals/progressive-breach-model.mmd).
+The breach progression is shown below as a timeline because the model is fundamentally chronological — each stage marks a step further along the path from untrusted input to organisational impact.
+
+```mermaid
+timeline
+  title Progressive breach progression
+  Influence : Untrusted language or data
+  Intent : Goal compromise
+  Action : Tool, workflow, or code
+  Authority : Credential or delegated authority
+  State : Memory or context change
+  Propagation : Across agents or systems
+  Autonomy : Unsafe autonomous action
+  Impact : Organisational impact
+```
+
+Source: [progressive-breach-model.mmd](../visuals/progressive-breach-model.mmd).
 
 Not every incident follows every stage. Some chains stop at unsafe disclosure or misleading advice. Others skip memory or multi-agent propagation. The model is useful because it makes defenders ask where influence becomes action and where action becomes durable impact.
 
@@ -142,8 +157,53 @@ For any proposed agentic workflow, ask where the chain would be interrupted:
 
 If the answer is unclear, the system is difficult to govern even if the model appears safe in isolation.
 
+## Engineering Patterns That Implement Each Interruption
+
+Each interruption question above maps to one or more secure engineering patterns. The patterns describe the boundaries, decision points, audit edges, and deny or revise branches that engineers can build to. Use the [secure engineering patterns overview](07-secure-engineering-patterns.md) for the full map; the table below is the quick lookup.
+
+| Interruption question | Pattern(s) |
+| --- | --- |
+| Can untrusted language be prevented from becoming control instruction? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Memory Security](../patterns/memory-security.md), [Secure MCP](../patterns/secure-mcp.md) |
+| Can goal alignment be checked before a risky tool call? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can policy decisions evaluate intent, authority, data sensitivity, and likely impact together? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can credentials be scoped to the task and revoked after use? | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Can memory writes be reviewed, expired, corrected, and traced? | [Memory Security](../patterns/memory-security.md) |
+| Can cross-agent messages preserve origin, trust level, and delegated scope? | Planned multi-agent pattern |
+| Can humans see enough evidence before approving sensitive action? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can the full path from influence to outcome be reconstructed after the fact? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), audit evidence sections in all five patterns |
+
+
 ## Relationship To Defence Architecture
 
 These chains show where controls need to operate. The [defence architecture](04-defence-architecture.md) organises those controls into layers for identity, policy decisions, runtime guardrails, tool brokering, credential brokering, memory and context controls, observability, human approval, audit, outcome control, and governance.
 
-The reusable Mermaid source for the agent, tool, memory, credential, and observability interaction model is available in [agent-tool-memory-attack-flow.mmd](../visuals/agent-tool-memory-attack-flow.mmd).
+The interaction between agent, policy, tool broker, tools, memory, and audit is shown below as a sequence diagram. The diagram is about who calls whom and in what order.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant P as Policy
+  participant B as Tool broker
+  participant T as Tool or MCP
+  participant M as Memory
+  participant L as Audit
+
+  U->>A: Goal
+  M-->>A: Retrieved memory
+  A->>P: Proposed plan
+  alt Allowed
+    P->>B: Allow
+    B->>T: Scoped call
+    T-->>A: Result
+  else Denied
+    P-->>A: Deny or revise
+  end
+  A->>M: Memory write
+  P->>L: Trace
+  B->>L: Trace
+  T->>L: Trace
+  M->>L: Trace
+```
+
+Source: [agent-tool-memory-attack-flow.mmd](../visuals/agent-tool-memory-attack-flow.mmd).

--- a/docs/04-defence-architecture.md
+++ b/docs/04-defence-architecture.md
@@ -39,7 +39,19 @@ These capabilities should not be isolated systems. Observation without interpret
 
 ## AI Defense Plane
 
-The AI Defense Plane organises controls into three operating layers: Discover, Protect, and Govern. The reusable Mermaid source is available in [ai-defense-plane.mmd](../visuals/ai-defense-plane.mmd).
+The AI Defense Plane organises controls into three operating layers: Discover, Protect, and Govern. The diagram below uses block syntax because the goal is to show the three layers as a stacked, conceptual architecture wrapping the agentic execution system, not to chart a process.
+
+```mermaid
+block-beta
+columns 3
+  Discover["Discover\nInventory and ownership"]
+  Protect["Protect\nRuntime decisions and controls"]
+  Govern["Govern\nAuthority, evidence, accountability"]
+  System["Agentic execution system: agents, context, tools, memory, authority, downstream"]:3
+  Evidence["Audit and assurance evidence"]:3
+```
+
+Source: [ai-defense-plane.mmd](../visuals/ai-defense-plane.mmd).
 
 | Layer | Responsibility | Examples |
 | --- | --- | --- |
@@ -65,7 +77,21 @@ A secure agentic architecture needs several control layers that share context. E
 | Human approval | Require informed review for sensitive, irreversible, ambiguous, or high-impact actions. | Does the reviewer see enough evidence to approve the action responsibly? | Source context, risk summary, parameters, identity, expected effect, approver, timestamp, and decision. |
 | Outcome control | Limit, verify, reverse, or contain downstream effects after action is attempted. | Did the result match the approved intent and acceptable impact? | Final state, validation result, notification, rollback, containment, and business owner record. |
 
-The reusable Mermaid source for a reference model is available in [secure-agent-reference-architecture.mmd](../visuals/secure-agent-reference-architecture.mmd).
+The reference architecture below shows the same layered control model as seven stacked components. The [agent, tool, and memory attack flow](../visuals/agent-tool-memory-attack-flow.mmd) sequence diagram already covers ordering.
+
+```mermaid
+block-beta
+columns 1
+  Inputs["Inputs: user goal, retrieved context, memory"]
+  Agent["Agent reasoning"]
+  Decision["Policy decision and approval gate"]
+  Brokers["Tool broker and credential broker"]
+  Execution["Tool runtime, MCP, or workflow"]
+  Outcome["Outcome control and downstream system"]
+  Audit["Observability and audit"]
+```
+
+Source: [secure-agent-reference-architecture.mmd](../visuals/secure-agent-reference-architecture.mmd).
 
 ## How The Layers Work Together
 
@@ -148,6 +174,24 @@ Use these questions when reviewing an agentic system:
 10. Do evaluations test multi-step behaviour across tools, memory, approvals, and downstream systems?
 
 If these answers are weak, the architecture may appear controlled at the model boundary while remaining exposed across the execution system.
+
+## Engineering Patterns Per Control Layer
+
+Each control layer above is the architectural placeholder for one or more secure engineering patterns. The patterns describe the same controls at the boundary, decision, audit, and deny or revise level engineers can build to. Use the [secure engineering patterns overview](07-secure-engineering-patterns.md) for the full map; the table below is the quick lookup.
+
+| Layer | Pattern(s) that implement it |
+| --- | --- |
+| Identity and access | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Policy decision | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Runtime guardrail | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| Tool broker | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Secure MCP](../patterns/secure-mcp.md) |
+| Credential broker | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Memory and context | [Memory Security](../patterns/memory-security.md) |
+| Observability and audit | [Secure Agent Runtime](../patterns/secure-agent-runtime.md); audit evidence sections in all five patterns |
+| Human approval | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Outcome control | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+
+The [secure engineering patterns overview diagram](../visuals/secure-engineering-patterns-overview.mmd) shows the same composition on a single picture: where this layered model places the decision points, the patterns name the engineering boundary that owns them.
 
 ## Relationship To The Field Guide
 

--- a/docs/07-secure-engineering-patterns.md
+++ b/docs/07-secure-engineering-patterns.md
@@ -1,0 +1,126 @@
+# Secure Engineering Patterns: From Defence Architecture To Code
+
+Secure engineering patterns are the implementation layer of the field guide. The earlier docs explain why agentic systems change risk ([landscape map](00-landscape-map.md)), how they fail ([threat model](01-threat-model.md)), where the failures enter ([attack surfaces](02-attack-surfaces.md)), how local weaknesses compose ([attack chains](03-agentic-attack-chains.md)), and which control layers should sit in the system ([defence architecture](04-defence-architecture.md)). This document closes the loop by connecting those control layers to reusable patterns engineers can build to.
+
+The mission is explicit on this connection:
+
+> Connect threats to practical defence architecture and secure engineering patterns.
+
+Patterns sit at the level where decisions become code. They are not vendor blueprints. They define the shape of the controls — the boundaries, decision points, audit edges, and deny or revise branches — that make an agentic system observable, interpretable, constrainable, and governable in line with the runtime security model in [defence architecture](04-defence-architecture.md).
+
+## Pattern Set
+
+Five patterns cover the boundaries where agentic risk most often becomes action. Each pattern follows the same shape: context, risk, recommended controls, boundary diagram, implementation notes, failure modes covered, evaluation checks, audit evidence, and limitations.
+
+| Pattern | One-line summary | Primary failure modes addressed |
+| --- | --- | --- |
+| [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | The pipeline of named stages around the agent reasoning step that observe, interpret, constrain, and audit every proposed action. | Prompt and instruction attacks; goal hijacking; unsafe autonomous action; monitoring and evaluation blind spots. |
+| [Secure Tool Calling](../patterns/secure-tool-calling.md) | A tool broker mediates every call with allowlist, schema validation, policy decision, scoped credential, output validation, and outcome control. | Tool misuse and unsafe composition; instruction attacks reaching action; unsafe autonomous action. |
+| [Secure MCP And Capability Governance](../patterns/secure-mcp.md) | A registry, server authentication, capability scope check, context isolation filter, and response validation around every MCP server, skill, or extension. | MCP, skill, and extension compromise; tool misuse via packaged capabilities; context poisoning via capability responses. |
+| [Memory Security](../patterns/memory-security.md) | Classification on write, provenance and expiry tags, read policy, freshness and source filter, and anomaly detection around every memory entry. | Memory poisoning; secret persistence; context poisoning via memory recall. |
+| [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) | A credential broker issues task-bound, least-privilege, short-lived tokens from vault-backed secrets, with secret filters on outputs and exercised revocation paths. | Credential and token misuse; authority over-grant; multi-agent propagation via shared identity. |
+
+These five compose. The runtime pattern enforces that tool calls go through the tool broker, that capabilities come from the registry, that memory writes pass classification, and that credentials are brokered. None of the four sibling patterns can be safely bypassed if the runtime is implemented well. The runtime cannot replace any of them.
+
+## How The Patterns Compose
+
+The overview diagram shows the five patterns operating around the secure agent reference architecture in a single picture. Read it as the engineering view of the [secure agent reference architecture](../visuals/secure-agent-reference-architecture.mmd): the architecture says where decisions sit, the overview says which pattern owns each decision.
+
+```mermaid
+block-beta
+columns 1
+  Runtime["Secure agent runtime: intake, policy, guardrail, approval"]
+  Engineering["Secure tool calling | Secure MCP | Credential and token boundaries | Memory security"]
+  Audit["Observability and audit"]
+```
+
+Source: [secure-engineering-patterns-overview.mmd](../visuals/secure-engineering-patterns-overview.mmd). 
+
+A request moves through:
+
+1. **Runtime intake.** The runtime pattern pins task scope, identity, allowlist, and trace identifier.
+2. **Reasoning.** The agent proposes a step using source-labelled context.
+3. **Policy decision.** The runtime evaluates the proposed step against intent, identity, and risk.
+4. **Tool path.** The tool broker validates allowlist and schema; the credential broker issues a scoped token; the MCP capability is authenticated and scope-checked; the context isolation filter narrows what crosses the host-to-server boundary.
+5. **Action.** The tool runtime or MCP server executes; output is validated and quarantined where needed; outcome control sits between the runtime and the downstream system.
+6. **Memory.** Memory writes are classified, tagged, and policy-checked; reads are filtered and source-labelled.
+7. **Audit.** Every stage emits to the audit channel under the same trace identifier.
+
+Every path has a deny, revise, or escalate branch in addition to allow. Every path has an audit edge. This is the contract patterns place on the implementation.
+
+## Threat And Surface To Pattern Map
+
+The mapping below ties the failure-mode taxonomy in [threat model](01-threat-model.md) and the surface map in [attack surfaces](02-attack-surfaces.md) to the patterns that address them. Use this as a starting checklist when reviewing a system, not as a substitute for the controls in each pattern.
+
+### Failure modes to patterns
+
+| Failure mode (from 01-threat-model) | Primary pattern(s) | Supporting pattern(s) |
+| --- | --- | --- |
+| 1. Prompt and instruction attacks | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | [Memory Security](../patterns/memory-security.md), [Secure MCP](../patterns/secure-mcp.md) |
+| 2. Goal hijacking | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| 3. Tool misuse and unsafe composition | [Secure Tool Calling](../patterns/secure-tool-calling.md) | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 4. Credential and token misuse | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Memory Security](../patterns/memory-security.md) |
+| 5. Context poisoning | [Memory Security](../patterns/memory-security.md) (recall path); planned context-poisoning pattern | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure MCP](../patterns/secure-mcp.md) |
+| 6. Memory poisoning | [Memory Security](../patterns/memory-security.md) | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| 7. MCP, skill, and extension compromise | [Secure MCP](../patterns/secure-mcp.md) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 8. Multi-agent propagation | Planned multi-agent pattern | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) (per-task identity), [Memory Security](../patterns/memory-security.md) (namespace isolation) |
+| 9. Unsafe autonomous action | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) (stop conditions, approvals, outcome control) | [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| 10. Monitoring and evaluation blind spots | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) (end-to-end trace) | All four siblings contribute audit evidence sections |
+
+### Attack surfaces to patterns
+
+| Surface (from 02-attack-surfaces) | Pattern(s) that address it |
+| --- | --- |
+| Instruction sources | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| Context and retrieval | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), planned context-poisoning pattern |
+| Tool interfaces | [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Credential boundaries | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Memory and state | [Memory Security](../patterns/memory-security.md) |
+| Code and automation | Planned sandboxing and code execution pattern; partially [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| MCP, skills, and extensions | [Secure MCP](../patterns/secure-mcp.md) |
+| Human approvals | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Policy decisions | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) |
+| Observability and evaluation | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) (audit evidence sections in all five patterns) |
+| Multi-agent communication | Planned multi-agent pattern |
+| Downstream systems | [Secure Tool Calling](../patterns/secure-tool-calling.md) (outcome control), [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+
+
+
+### Chain interruptions to patterns
+
+The interruption checklist in [attack chains](03-agentic-attack-chains.md) lists eight defensive questions. Patterns map to those questions as follows:
+
+| Interruption question | Pattern(s) |
+| --- | --- |
+| Can untrusted language be prevented from becoming control instruction? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Memory Security](../patterns/memory-security.md), [Secure MCP](../patterns/secure-mcp.md) |
+| Can goal alignment be checked before a risky tool call? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can policy decisions evaluate intent, authority, data sensitivity, and likely impact together? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can credentials be scoped to the task and revoked after use? | [Credential And Token Boundaries](../patterns/credential-and-token-boundaries.md) |
+| Can memory writes be reviewed, expired, corrected, and traced? | [Memory Security](../patterns/memory-security.md) |
+| Can cross-agent messages preserve origin, trust level, and delegated scope? | Planned multi-agent pattern |
+| Can humans see enough evidence before approving sensitive action? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md), [Secure Tool Calling](../patterns/secure-tool-calling.md) |
+| Can the full path from influence to outcome be reconstructed after the fact? | [Secure Agent Runtime](../patterns/secure-agent-runtime.md) (linked trace), audit evidence sections in all five patterns |
+
+
+## Reader Paths
+
+The five patterns are written so different readers can pick up the parts they need without reading the whole set. Suggested reading orders:
+
+- **AI leaders and CTOs.** Start with [00 landscape map](00-landscape-map.md) and [04 defence architecture](04-defence-architecture.md). Then read this document and the context, risk, and limitations sections of each pattern. The aim is to understand which boundaries the engineering layer must enforce and what the residual risk looks like.
+- **AI engineers and security engineers.** Start with [01 threat model](01-threat-model.md), [02 attack surfaces](02-attack-surfaces.md), and [03 attack chains](03-agentic-attack-chains.md). Then read each pattern in full, focusing on recommended controls, boundary diagram, implementation notes, evaluation checks, and audit evidence. Use this document's threat-to-pattern map as a checklist when reviewing a system.
+- **Governance leaders.** Start with [00 landscape map](00-landscape-map.md), [04 defence architecture](04-defence-architecture.md), and the audit evidence sections of each pattern. The audit evidence sections describe what the organisation should be able to retrieve for assurance, incident response, and accountability.
+- **Researchers.** Start with [10 open research questions](10-open-research-questions.md), then read the failure modes covered and limitations sections of each pattern to see where current patterns are firmest and where they remain partial.
+
+## Relationship To Other Sections
+
+This document is the bridge between the conceptual docs and the patterns. The earlier docs name the problem space; the patterns name the implementation; this document keeps them aligned.
+
+- [00 landscape map](00-landscape-map.md) — the system-level map this engineering layer protects.
+- [01 threat model](01-threat-model.md) — the failure modes patterns address.
+- [02 attack surfaces](02-attack-surfaces.md) — the surfaces patterns guard.
+- [03 attack chains](03-agentic-attack-chains.md) — the chains patterns interrupt.
+- [04 defence architecture](04-defence-architecture.md) — the control layers patterns implement.
+- [patterns/](../patterns/) — the patterns themselves.
+- [visuals/](../visuals/) — the diagrams referenced from each pattern, including the [overview](../visuals/secure-engineering-patterns-overview.mmd).
+
+Patterns are living. As new failure modes, surfaces, or chain patterns are added, the maps in this document should be updated. 

--- a/docs/09-incident-case-studies.md
+++ b/docs/09-incident-case-studies.md
@@ -2,6 +2,23 @@
 
 This section presents real-world and plausible hypothetical case studies of agentic AI security incidents, using a consistent, evidence-labelled template. Each case is designed to be clear, comparable, and useful for learning.
 
+The state diagram below shows the lifecycle each case study walks through: from detected to closed.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Detected
+  Detected --> Reconstructed : trace and surface review
+  Reconstructed --> Mapped : align to attack chain
+  Mapped --> Analysed : controls failed and would have helped
+  Analysed --> PatternUpdated : update or extend pattern
+  Analysed --> EvalAdded : add evaluation or red-team test
+  PatternUpdated --> Closed
+  EvalAdded --> Closed
+  Closed --> [*]
+```
+
+Source: [case-study-lifecycle.mmd](../visuals/case-study-lifecycle.mmd).
+
 ## Case Study Template
 
 - **Title:**

--- a/docs/10-open-research-questions.md
+++ b/docs/10-open-research-questions.md
@@ -2,6 +2,22 @@
 
 This section collects actionable, relevant open research questions for the field of agentic execution security. Each question is linked to prior phases and resources where possible.
 
+The state diagram below shows the lifecycle each question moves through: from a failure mode in the threat model, through pattern alignment, gap identification, question framing, evaluation, evidence, and pattern revision. 
+
+```mermaid
+stateDiagram-v2
+  [*] --> FailureMode
+  FailureMode --> Pattern : map to existing pattern
+  Pattern --> Gap : identify control gap
+  Gap --> Question : frame research question
+  Question --> Eval : propose evaluation
+  Eval --> Evidence : produce results
+  Evidence --> Revision : new pattern or revision
+  Revision --> [*]
+```
+
+Source: [open-research-framing.mmd](../visuals/open-research-framing.mmd).
+
 ## Example Questions
 
 1. **How can agentic systems reliably distinguish between benign and malicious tool use in ambiguous contexts?**

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,29 @@
 
 This section is the conceptual map for agentic AI security. It will explain how risks emerge across the full execution system around a model: prompts, retrieved context, tools, credentials, memory, code execution, approvals, delegated authority, and multi-agent workflows.
 
-The goal is to help readers understand failure modes and control boundaries before they move into resource lists, engineering patterns, diagrams, or assessment rubrics.
+The goal is to help readers understand failure modes and control boundaries before they move into resource lists, engineering patterns, diagrams, or assessment rubrics. Secure engineering patterns translate the threat model and defence architecture into reusable, diagrammed implementation controls that engineers can build to.
+
+The mindmap below groups the documents in this section into four families: conceptual foundations, composition, engineering, and evidence. 
+
+```mermaid
+mindmap
+  root((Field guide))
+    Conceptual
+      00 Landscape
+      01 Threat model
+      02 Surfaces
+    Composition
+      03 Attack chains
+      04 Defence architecture
+    Engineering
+      07 Patterns
+      patterns/ files
+    Evidence
+      09 Case studies
+      10 Open questions
+```
+
+Source: [docs-reading-map.mmd](../visuals/docs-reading-map.mmd).
 
 ## Available Now
 
@@ -10,7 +32,9 @@ The goal is to help readers understand failure modes and control boundaries befo
 - [Threat Model: Agentic AI Failure Modes](01-threat-model.md) defines the first threat taxonomy as failure modes, preconditions, impact, and control questions.
 - [Attack Surfaces: Agentic Execution Systems](02-attack-surfaces.md) maps where language, context, authority, state, tools, memory, approvals, policies, and downstream systems expose risk.
 - [Agentic Attack Chains: From Influence To Impact](03-agentic-attack-chains.md) shows how local weaknesses compose into breach paths and where defenders can interrupt them.
+- [Agentic Attack Chain Library](agentic-attack-chains/README.md) provides a structured set of high-value attack chain stubs and a standard template for new chains.
 - [Defence Architecture: Securing Agentic Execution](04-defence-architecture.md) defines the layered control model for observing, interpreting, constraining, auditing, discovering, protecting, and governing agentic systems.
+- [Secure Engineering Patterns: From Defence Architecture To Code](07-secure-engineering-patterns.md) maps the threat model, attack surfaces, and chain interruptions to five reusable patterns (runtime, tool calling, MCP, memory, credentials), each with a boundary diagram, evaluation checks, and audit evidence requirements.
 
 ## Planned Coverage
 
@@ -21,12 +45,9 @@ Future docs will also cover:
 
 ## Reader Path
 
-AI leaders and CTOs should use this section to understand why agentic systems change security architecture and assurance expectations.
+AI leaders and CTOs should use this section to understand why agentic systems change security architecture and assurance expectations. Start with [00 landscape map](00-landscape-map.md) and [04 defence architecture](04-defence-architecture.md), then read the context, risk, and limitations sections of [07 secure engineering patterns](07-secure-engineering-patterns.md).
 
-AI engineers and security engineers should use it to map where controls need to sit across the execution environment.
+AI engineers and security engineers should use it to map where controls need to sit across the execution environment. Read [01 threat model](01-threat-model.md), [02 attack surfaces](02-attack-surfaces.md), and [03 attack chains](03-agentic-attack-chains.md), then [07 secure engineering patterns](07-secure-engineering-patterns.md) and the individual files in [patterns/](../patterns/).
 
-Governance leaders and researchers should use it to connect delegated authority, evidence, audit, evaluation, and open problems.
+Governance leaders and researchers should use it to connect delegated authority, evidence, audit, evaluation, and open problems. The audit evidence sections in each pattern describe what the organisation should be able to retrieve for assurance, incident response, and accountability.
 
-## Editorial Standard
-
-Docs in this section should be calm, precise, and evidence-led. Risks should be described as failure modes, breach paths, and control requirements rather than as isolated terms or unsupported claims.

--- a/docs/agentic-attack-chains/README.md
+++ b/docs/agentic-attack-chains/README.md
@@ -1,0 +1,53 @@
+# Agentic Attack Chain Library
+
+This section provides a structured library of high-value agentic attack chains, each using a standard template. The goal is to help readers understand how specific failure paths emerge in agentic AI systems and how they can be detected, controlled, and mitigated.
+
+The mindmap below indexes the chains by the progressive-breach-model stage they represent. 
+
+```mermaid
+mindmap
+  root((Chain library))
+    Influence
+      Prompt injection to tool misuse
+      Poisoned retrieved context
+      Hidden instruction in document ingestion
+    Action
+      Code execution side effects
+    Authority
+      Credential overreach
+    State
+      Memory poisoning
+    Capability
+      Unsafe MCP or tool extension
+    Propagation
+      Agent-to-agent contamination
+    Governance
+      Fake approval loop
+      Workflow automation abuse
+```
+
+Source: [chain-library-index.mmd](../../visuals/chain-library-index.mmd).
+
+## Available Attack Chain Stubs
+
+- [Prompt Injection to Tool Misuse](prompt-injection-tool-misuse.md)
+- [Poisoned Retrieved Context](poisoned-retrieved-context.md)
+- [Memory Poisoning](memory-poisoning.md)
+- [Unsafe MCP/Tool Extension](unsafe-mcp-tool-extension.md)
+- [Credential Overreach](credential-overreach.md)
+- [Fake Approval Loop](fake-approval-loop.md)
+- [Agent-to-Agent Contamination](agent-to-agent-contamination.md)
+- [Code-Execution Side Effects](code-execution-side-effects.md)
+- [Hidden Instruction in Document Ingestion](hidden-instruction-document-ingestion.md)
+- [Workflow Automation Abuse](workflow-automation-abuse.md)
+
+See the [Attack Chain Template](attack-chain-template.md) for the standard structure to use when adding new chains.
+
+---
+
+**Related:**
+- [Threat Model](../01-threat-model.md)
+- [Attack Surfaces](../02-attack-surfaces.md)
+- [Agentic Attack Chains Overview](../03-agentic-attack-chains.md)
+- [Defence Architecture](../04-defence-architecture.md)
+- [Secure Engineering Patterns](../../patterns/README.md)

--- a/docs/agentic-attack-chains/agent-to-agent-contamination.md
+++ b/docs/agentic-attack-chains/agent-to-agent-contamination.md
@@ -1,0 +1,6 @@
+# Agent-to-Agent Contamination
+
+Malicious data or instructions propagate from one agent to another, spreading compromise.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [docs/03-agentic-attack-chains.md](../03-agentic-attack-chains.md)

--- a/docs/agentic-attack-chains/attack-chain-template.md
+++ b/docs/agentic-attack-chains/attack-chain-template.md
@@ -1,0 +1,15 @@
+# Attack Chain Template
+
+- **Attack Chain:**
+- **Threat:**
+- **Preconditions:**
+- **System boundary:**
+- **Agent capability:**
+- **Failure path:**
+- **Detection signals:**
+- **Control points:**
+- **Mitigation pattern:**
+- **Test case:**
+- **Residual risk:**
+
+> Use this template for each new attack chain. See stubs for examples.

--- a/docs/agentic-attack-chains/code-execution-side-effects.md
+++ b/docs/agentic-attack-chains/code-execution-side-effects.md
@@ -1,0 +1,6 @@
+# Code-Execution Side Effects
+
+Agent executes code with unintended or unsafe side effects, breaching system boundaries.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)

--- a/docs/agentic-attack-chains/credential-overreach.md
+++ b/docs/agentic-attack-chains/credential-overreach.md
@@ -1,0 +1,6 @@
+# Credential Overreach
+
+Agent or tool is granted excessive credentials, enabling privilege escalation or data exfiltration.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/credential-and-token-boundaries.md](../../patterns/credential-and-token-boundaries.md)

--- a/docs/agentic-attack-chains/fake-approval-loop.md
+++ b/docs/agentic-attack-chains/fake-approval-loop.md
@@ -1,0 +1,6 @@
+# Fake Approval Loop
+
+Agent simulates or bypasses human approval, executing actions without real oversight.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)

--- a/docs/agentic-attack-chains/hidden-instruction-document-ingestion.md
+++ b/docs/agentic-attack-chains/hidden-instruction-document-ingestion.md
@@ -1,0 +1,6 @@
+# Hidden Instruction in Document Ingestion
+
+Instructions are hidden in ingested documents, causing the agent to act unexpectedly.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)

--- a/docs/agentic-attack-chains/memory-poisoning.md
+++ b/docs/agentic-attack-chains/memory-poisoning.md
@@ -1,0 +1,6 @@
+# Memory Poisoning
+
+Malicious input corrupts agent memory, leading to unsafe or unintended actions.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/memory-security.md](../../patterns/memory-security.md)

--- a/docs/agentic-attack-chains/poisoned-retrieved-context.md
+++ b/docs/agentic-attack-chains/poisoned-retrieved-context.md
@@ -1,0 +1,6 @@
+# Poisoned Retrieved Context
+
+Retrieved context is manipulated to influence agent behaviour or outputs.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/memory-security.md](../../patterns/memory-security.md)

--- a/docs/agentic-attack-chains/prompt-injection-tool-misuse.md
+++ b/docs/agentic-attack-chains/prompt-injection-tool-misuse.md
@@ -1,0 +1,6 @@
+# Prompt Injection to Tool Misuse
+
+A malicious prompt causes the agent to misuse a tool, breaching intended boundaries.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [docs/02-attack-surfaces.md](../02-attack-surfaces.md), [patterns/secure-tool-calling.md](../../patterns/secure-tool-calling.md)

--- a/docs/agentic-attack-chains/unsafe-mcp-tool-extension.md
+++ b/docs/agentic-attack-chains/unsafe-mcp-tool-extension.md
@@ -1,0 +1,6 @@
+# Unsafe MCP/Tool Extension
+
+An untrusted or unsafe extension to the MCP or tool interface enables new attack paths.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-mcp.md](../../patterns/secure-mcp.md)

--- a/docs/agentic-attack-chains/workflow-automation-abuse.md
+++ b/docs/agentic-attack-chains/workflow-automation-abuse.md
@@ -1,0 +1,6 @@
+# Workflow Automation Abuse
+
+Agentic workflow automation is abused to escalate privileges or bypass controls.
+
+- See [attack-chain-template.md](attack-chain-template.md) for full structure.
+- Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,11 +57,24 @@ nav:
       - Threat Model: docs/01-threat-model.md
       - Attack Surfaces: docs/02-attack-surfaces.md
       - Agentic Attack Chains: docs/03-agentic-attack-chains.md
-      - Defence Architecture: docs/04-defence-architecture.md
-      - Red Teaming & Evaluation: docs/05-red-teaming-and-evaluation.md
-      - Benchmarks: docs/06-benchmarks.md
-      - Incident Case Studies: docs/09-incident-case-studies.md
-      - Open Research Questions: docs/10-open-research-questions.md
+        - Defence Architecture: docs/04-defence-architecture.md
+        - Agentic Attack Chain Library:
+          - Attack Chain Stubs Index: docs/agentic-attack-chains/README.md
+          - Prompt Injection to Tool Misuse: docs/agentic-attack-chains/prompt-injection-tool-misuse.md
+          - Poisoned Retrieved Context: docs/agentic-attack-chains/poisoned-retrieved-context.md
+          - Memory Poisoning: docs/agentic-attack-chains/memory-poisoning.md
+          - Unsafe MCP/Tool Extension: docs/agentic-attack-chains/unsafe-mcp-tool-extension.md
+          - Credential Overreach: docs/agentic-attack-chains/credential-overreach.md
+          - Fake Approval Loop: docs/agentic-attack-chains/fake-approval-loop.md
+          - Agent-to-Agent Contamination: docs/agentic-attack-chains/agent-to-agent-contamination.md
+          - Code-Execution Side Effects: docs/agentic-attack-chains/code-execution-side-effects.md
+          - Hidden Instruction in Document Ingestion: docs/agentic-attack-chains/hidden-instruction-document-ingestion.md
+          - Workflow Automation Abuse: docs/agentic-attack-chains/workflow-automation-abuse.md
+          - Attack Chain Template: docs/agentic-attack-chains/attack-chain-template.md
+        - Red Teaming & Evaluation: docs/05-red-teaming-and-evaluation.md
+        - Benchmarks: docs/06-benchmarks.md
+        - Incident Case Studies: docs/09-incident-case-studies.md
+        - Open Research Questions: docs/10-open-research-questions.md
   - Patterns: patterns/README.md
   - Resources: resources/README.md
   - Visuals: visuals/README.md

--- a/patterns/README.md
+++ b/patterns/README.md
@@ -1,8 +1,29 @@
 # Patterns
 
-This section will hold secure engineering patterns for agentic systems. The focus is practical: how to design controls around the full system of action rather than relying only on model-level filtering.
+This section holds secure engineering patterns for agentic systems. The focus is practical: how to design controls around the full system of action rather than relying only on model-level filtering.
 
-Patterns should connect a system context to a risk, a recommended control, implementation considerations, validation checks, and known limitations.
+Patterns connect a system context to a risk, a recommended control, implementation considerations, validation checks, and known limitations. Each pattern follows the standard shape below.
+
+```mermaid
+mindmap
+  root((Pattern shape))
+    Why
+      Context
+      Risk
+    What
+      Recommended controls
+      Boundary diagram
+    How
+      Implementation notes
+    Coverage
+      Failure modes covered
+      Evaluation checks
+      Audit evidence
+    Caveats
+      Limitations
+```
+
+Source: [pattern-shape.mmd](../visuals/pattern-shape.mmd). A mindmap is used because the pattern shape is a conceptual taxonomy of sections, not a process — readers should see the standard structure at a glance.
 
 ## Planned Coverage
 

--- a/patterns/credential-and-token-boundaries.md
+++ b/patterns/credential-and-token-boundaries.md
@@ -1,30 +1,136 @@
 # Credential and Token Boundaries
 
 ## Context
-Agentic systems often require credentials or tokens to access tools, APIs, or data. Improper handling can lead to leaks, misuse, or privilege escalation.
+
+Credentials and tokens determine what an agentic action can affect. They turn a proposed step into an authorised change in real systems. In agentic systems, authority is rarely a single user session — it can come from a user identity, a service identity, a delegated scope, an API key, a workflow runner, a cloud role, or an approval system.
+
+This pattern applies wherever an agent host can:
+
+- Reach a secret store or identity provider.
+- Acquire credentials for tool calls, MCP servers, downstream APIs, code execution, or workflow steps.
+- Hold credentials in process memory, prompts, retrieved context, tool output, logs, or persistent memory.
+- Pass credentials to capabilities that execute on the agent's behalf.
+
+The pattern sits next to the secure tool calling pattern and the MCP pattern: those patterns decide that an action should happen and which capability runs it; this pattern decides which authority is used and how it is bound to the task.
 
 ## Risk
-- Leaked credentials can enable unauthorized access.
-- Overbroad tokens may grant excessive privileges.
-- Poor isolation can allow lateral movement between agents or tasks.
+
+Credential boundaries concentrate several failure modes from [docs/01-threat-model.md](../docs/01-threat-model.md):
+
+- **Authority over-grant.** The agent acts under a long-lived, broadly scoped credential. A narrow request can change repositories, cloud resources, SaaS records, communications, or financial state outside the intended scope.
+- **Identity confusion.** Service or admin identities are reused across tasks and users. Audit records cannot distinguish whose action it was.
+- **Credential leakage.** Tokens reach prompts, retrieved context, tool output, model-visible context, memory, or logs. They are then re-exposed across tasks, traces, or sessions.
+- **Stale or shared tokens.** Reused tokens enable lateral movement between agents, tasks, or environments after a single compromise.
+- **Implicit elevation.** A capability that requires elevated scope is invoked under a token that already has it, even though the task did not need it.
+- **Slow revocation.** A compromised credential continues to work because revocation is manual, partial, or delayed across systems.
+- **Approval-credential mismatch.** A human approves a narrow action; the credential issued for execution is broader.
 
 ## Recommended Controls
-- Use scoped, short-lived tokens for each agent/task.
-- Store credentials securely (vaults, environment variables, not code).
-- Enforce least-privilege on all credentials and tokens.
-- Monitor credential usage and rotate regularly.
+
+Authority should be brokered, scoped, time-limited, task-bound, and observable.
+
+1. **Credential broker.** All credentials used by the agent and its capabilities are issued by a broker that knows the user, task, capability, and approved scope. The agent does not hold long-lived credentials.
+2. **Task-bound issuance.** Each credential is bound to a task identifier, a capability identifier, and the approved action. Out-of-task or out-of-capability use is denied.
+3. **Least-privilege scope.** The broker selects the narrowest scope that completes the operation. A read does not get write scope; a single record update does not get bulk scope.
+4. **Short lifetime.** Credentials expire on completion of the call, end of the task, or a small time window — whichever is shortest.
+5. **Pre-issuance scope and lifetime check.** A policy check confirms the scope and lifetime are within the approved boundary before issuance.
+6. **Vault-backed secrets.** Long-lived secrets (root credentials, refresh tokens) live in a vault. The broker uses them to mint short-lived tokens; agents and capabilities never receive the long-lived material.
+7. **Secret filter on outputs and logs.** Tool output, prompts, model-visible context, memory candidates, and logs pass through a filter that detects and redacts secret-shaped content before further use.
+8. **Revocation paths.** Each credential type has a documented and exercised revocation path. Emergency revocation should propagate within minutes across the broker, the issuing system, and any caches.
+9. **Approval-credential alignment.** When a human approves an action, the credential issued must match the approved scope. The broker should not issue broader scope than the approval covers.
+10. **Identity in audit.** Effective identity, scope, lifetime, task binding, capability, and approval reference appear in every audit record for an action.
+
+## Boundary Diagram
+
+The flow diagram traces a credential from user identity and approved task, through the broker, the scope and lifetime check, the vault-backed secret source, and the policy check, to a scoped short-lived token used by a single tool, MCP server, or workflow. The expiry and revocation events feed back to the broker, and the secret filter sits on the output path.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Requested
+  Requested --> Denied : scope too broad
+  Requested --> Issued : task-bound and short-lived
+  Issued --> InUse : tool call
+  InUse --> Issued : continue
+  Issued --> Expired : lifetime ends
+  InUse --> Revoked : task ends or breach signal
+  Issued --> Revoked : task ends or breach signal
+  Expired --> [*]
+  Revoked --> [*]
+  Denied --> [*]
+```
+
+Source: [credential-token-boundaries.mmd](../visuals/credential-token-boundaries.mmd).The picture clarifies that every token has an explicit end-of-life event.
 
 ## Implementation Notes
-- Integrate with secret management systems.
-- Audit all credential accesses and uses.
-- Apply token scoping and expiration policies.
+
+- **Centralise issuance.** A single broker (or a small set of brokers per environment) is easier to monitor and audit than per-tool credential handling. Make it the default path; treat anything else as an exception.
+- **Bind to the task identifier early.** Issue credentials only after the task has a pinned scope, an approved capability list, and a trace identifier. Tokens that float free of a task are harder to revoke and audit.
+- **Prefer short lifetimes over wide scopes.** A token that lives for one call is easier to reason about than a token that lives for an hour. Combine with rate limits at the tool broker.
+- **Use a vault for long-lived secrets and never expose them to agent context.** Root credentials, OAuth refresh tokens, and signing keys must not appear in prompts, retrieved content, memory, or model-visible state.
+- **Filter outputs before they re-enter reasoning.** Tool output, MCP server responses, and downstream messages should pass through a secret filter. The filter should redact and log, not silently drop.
+- **Filter logs and traces too.** Audit usefulness depends on logs being safe to read. The same secret filter should sit on the logging path.
+- **Map every approval to a credential decision.** When a human approves an action, record the scope they approved. The broker should refuse to issue beyond it.
+- **Test revocation regularly.** A revocation path that has never been exercised will fail under pressure. Run synthetic revocation drills as part of routine work, not only after incidents.
+- **Plan for capability-level identity.** Where possible, each capability uses a credential issued for that capability and task. A single shared identity across capabilities undoes the benefit of brokering.
+- **Watch for exfiltration patterns.** A burst of read tokens followed by an outbound send is a known unsafe composition. The tool broker (see [secure-tool-calling.md](secure-tool-calling.md)) should detect; the credential broker should be the place to enforce expiry and revocation.
+
+## Failure Modes Covered
+
+Direct coverage from the [threat model](../docs/01-threat-model.md):
+
+- **Credential and token misuse** — primary coverage; this pattern exists for it.
+- **Tool misuse via authority over-grant** — least-privilege scope, task-binding, and short lifetimes reduce blast radius when a tool is misused.
+- **MCP, skill, and extension compromise blast radius** — per-capability identity contains a compromised capability to its scope.
+- **Multi-agent propagation via shared identity** — task-bound credentials prevent one agent's compromise from acting through another's authority.
+- **Unsafe autonomous action with broad authority** — short lifetimes and approval-credential alignment keep autonomy bounded.
+
+Partial coverage:
+
+- **Prompt and instruction attacks reaching authority** — secret filters on outputs and logs prevent leakage; instruction-data separation lives in the runtime pattern.
+- **Memory poisoning that includes secrets** — classification refuses secrets in memory; this pattern removes the need for the agent to remember secrets in the first place.
 
 ## Evaluation Checks
-- Are credentials stored and accessed securely?
-- Are tokens scoped and short-lived?
-- Is credential usage monitored and audited?
+
+- Does the agent hold any long-lived credential outside the broker? A red-team review of the agent host process and configuration should find none.
+- For each capability, is there a defined credential type, scope, lifetime, and issuance path? Capabilities without one should not be in the registry.
+- For ten randomly selected actions, can a reviewer recover the trace identifier, identity used, scope, lifetime, task binding, capability, and approval reference?
+- When a synthetic test asks the agent to act outside its task scope, does the broker refuse to issue a credential and log the attempt?
+- When an approval narrows the action below the requested scope, does the broker issue a credential matching the approval, not the request?
+- Does the secret filter detect and redact synthetic secret-shaped content in tool output, prompts, memory candidates, and logs?
+- Does emergency revocation propagate within the documented target across the broker, issuing system, and caches?
+- Are revocation drills exercised on a recurring basis? Is the most recent drill date visible to operators?
+
+## Audit Evidence
+
+For each action that used a credential, a reviewer should be able to retrieve under the task's trace identifier:
+
+- The user or workflow identity that owns the task and the approved task scope.
+- The broker decision (allow, deny, narrow), the matched policy, the scope and lifetime issued, and the capability target.
+- The credential type, issuance time, expiry, and binding (task, capability, approval reference) — without the secret value.
+- The vault source of the long-lived secret used to mint the short-lived token, where applicable.
+- The capability or tool runtime that received the credential and the action it took.
+- The secret-filter result on outputs and logs (passed clean, redacted, blocked).
+- The revocation event, if any (cause, target, propagation result).
+- The approval record, where required, including the approver identity, evidence shown, and approved scope.
+
+Audit records should be queryable by identity, by task, by capability, by approval reference, and by scope.
 
 ## Limitations
-- Frequent rotation may disrupt agent workflows.
-- Overly narrow scopes can block legitimate actions.
-- Secret management integration may add complexity.
+
+- A credential broker depends on a healthy identity and secret-management infrastructure. Without that foundation, the broker becomes a single point of failure or a bottleneck.
+- Per-call short lifetimes increase issuance volume and can create operational noise. Rate, batch, and cache decisions should be tuned to keep audit clean without overwhelming the broker.
+- Secret filters miss novel formats and can produce false positives. Combine deterministic patterns with a periodic review of redaction rates and incidents.
+- Approval-credential alignment requires that approval prompts capture scope, not only intent. Approval interfaces that show only a free-text summary make this hard.
+- Some legacy systems do not support short-lived scoped tokens. For those, compensate with stricter tool broker policy, tighter approvals, and shorter task horizons.
+- Capability-level identity adds operational work. Teams should plan for identity provisioning, lifecycle, and incident response per capability.
+- A broker cannot prevent misuse of an issued, in-scope token within its valid window. Outcome control, rate limits, and per-capability rate limits are the compensating controls in that window.
+
+## Related
+
+- [docs/01-threat-model.md](../docs/01-threat-model.md) — failure mode 4 (credential and token misuse).
+- [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md) — Credential and Authority Surfaces.
+- [docs/03-agentic-attack-chains.md](../docs/03-agentic-attack-chains.md) — Chain Pattern 4 (broad authority to downstream change).
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — Identity and access, credential broker, and human approval layers.
+- Sibling patterns: [secure-agent-runtime.md](secure-agent-runtime.md), [secure-tool-calling.md](secure-tool-calling.md), [secure-mcp.md](secure-mcp.md), [memory-security.md](memory-security.md).
+
+Maturity: stable defensive guidance. Last reviewed: 2026-04-29.

--- a/patterns/memory-security.md
+++ b/patterns/memory-security.md
@@ -1,30 +1,132 @@
 # Memory Security
 
 ## Context
-Agentic systems use memory to store context, intermediate results, and user data. Memory can be a target for poisoning, leakage, or unauthorized access.
+
+Agentic systems use memory to carry context, intermediate results, learned preferences, summaries, and task state across steps and sessions. Memory makes agents useful over time, and it is also where a transient compromise can become persistent.
+
+This pattern applies wherever an agent host can:
+
+- Write to a memory store from agent reasoning, tool output, retrieved content, or another agent's output.
+- Retrieve memory entries into a future reasoning step, approval prompt, or tool call.
+- Share memory across tasks, sessions, users, or agents.
+- Summarise prior context and store the summary as new memory.
+
+Memory sits next to the runtime, the tool calling pattern, and the MCP pattern — most memory writes are triggered by something one of those patterns produced. Memory is a separate pattern because the failure mode (persistence and reuse) differs from a single-step risk.
 
 ## Risk
-- Memory poisoning can alter agent behavior or outcomes.
-- Leaked memory may expose sensitive data.
-- Uncontrolled memory growth can lead to denial of service.
+
+Memory concentrates several failure modes from [docs/01-threat-model.md](../docs/01-threat-model.md):
+
+- **Memory poisoning.** Manipulated facts, preferences, or instruction-shaped content are written to memory and influence later sessions, approvals, or tool calls. The original influence may be untraceable by the time it acts.
+- **Secret persistence.** Tool output, prompts, or retrieved content carrying tokens, keys, or sensitive identifiers are written to memory and re-exposed across tasks.
+- **Provenance loss.** A summary of summaries strips source, freshness, and trust labels. The agent later treats stripped memory as authoritative.
+- **Cross-task and cross-user leakage.** Memory written for one user, task, or scope is retrieved into another, breaking isolation.
+- **Stale memory.** Facts true at the time of the write become misleading later, but no expiry or freshness check forces revision.
+- **Unbounded growth.** Memory grows without retention rules, making review, governance, and incident response slower and less complete.
+- **Untrusted instruction in memory.** Memory entries that read like instructions (role redefinitions, allowlist overrides) can be retrieved and silently expand the agent's authority.
 
 ## Recommended Controls
-- Validate and sanitize all memory writes.
-- Encrypt sensitive memory segments.
-- Implement memory access controls and audit logs.
-- Monitor for unusual memory access patterns.
+
+Memory should be treated as security-relevant state, with explicit controls on writes, reads, lifecycle, and content classes.
+
+1. **Classification before write.** Every memory candidate is classified into an allowed category. Categories such as user preference, task state, factual summary, and operational note are permitted; secrets, untrusted instructions, and policy overrides must never be stored.
+2. **Write policy decision.** A policy stage approves, denies, or requires review for each candidate. The policy sees source, classification, sensitivity, and the task scope.
+3. **Provenance, owner, scope, and expiry tags.** Every memory entry carries source, owner, task or session scope, write reason, and an expiry. Entries without these tags are not retrievable.
+4. **Read policy decision.** Reads pass a policy check that uses task scope, identity, and entry tags. Out-of-scope reads are denied or redacted.
+5. **Provenance and freshness filter at read.** Retrieved entries are filtered, source-labelled, and presented as quoted evidence rather than as authoritative truth.
+6. **Instruction-data separation in memory.** Memory content that re-enters the reasoning step is treated as data. The runtime should refuse to let memory redefine goals, allowlists, or policy.
+7. **Reviewer-visible memory.** Users and reviewers can list, inspect, correct, expire, and delete memory entries that affect them.
+8. **Anomaly detection.** Sudden changes in memory volume, content distribution, or retrieval patterns trigger alert and quarantine. Specific drift signals (instruction-shaped content, suspected secrets) should be flagged on write and on read.
+9. **Retention and deletion rules.** Default expiry by category. Hard caps on volume per scope. Deletion paths that are exercised, not only documented.
+10. **Logging of writes and influential reads.** Every write is logged. Reads that influence a tool call, approval, or downstream action are linked to the action under the same trace identifier.
+
+## Boundary Diagram
+
+The flow diagram shows the write path (source, classification, policy check, optional review, provenance tagging, store) and the read path (request, policy check, provenance and freshness filter, injection into context). It also makes the anomaly-detection and audit edges explicit.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Proposed
+  Proposed --> Classified : classify
+  Classified --> Blocked : secret or instruction
+  Classified --> ReviewPending : needs review
+  ReviewPending --> Blocked : rejected
+  ReviewPending --> Tagged : approved
+  Classified --> Tagged : auto-allow
+  Tagged --> Stored
+  Stored --> Retrieved : read policy passes
+  Retrieved --> Stored
+  Stored --> Quarantined : anomaly detected
+  Stored --> Expired : expiry or deletion
+  Expired --> [*]
+  Blocked --> [*]
+  Quarantined --> [*]
+```
+
+Source: [memory-security-flow.mmd](../visuals/memory-security-flow.mmd). The state model makes the lifecycle explicit and shows that memory is not a passive store — every entry passes a write policy on the way in and a read policy on the way out.
 
 ## Implementation Notes
-- Use schemas and validation for memory entries.
-- Apply least-privilege access to memory APIs.
-- Integrate memory logs with observability stack.
+
+- **Pin a memory namespace per task and per scope.** Tasks should write into and read from explicit namespaces, not a global store. Cross-namespace reads should be a deliberate, policy-gated operation.
+- **Classify on the way in.** Use deterministic rules first (regexes for secrets, known instruction templates for prompt-injection patterns) and a model-based classifier as a backstop, not the other way round. Deterministic rules are easier to audit.
+- **Refuse the unclassifiable.** If the system cannot classify a candidate confidently, the default is do not store. A small loss of recall is preferable to writing untrusted content.
+- **Tag everything.** Source, owner, scope, expiry, write reason, classifier confidence, and the trace identifier of the originating step. Untagged entries should not survive a periodic sweep.
+- **Treat summaries as new entries.** A summary inherits the lowest trust level among its sources, not the highest. Summaries do not erase provenance debt.
+- **Keep secrets out of memory by construction.** The credential broker (see [credential-and-token-boundaries.md](credential-and-token-boundaries.md)) should issue credentials per call, so there is no need for the agent to remember them. If the agent appears to need to remember a secret, redesign the tool flow.
+- **Make deletion real.** Soft-delete with no purge schedule does not satisfy reviewer-visible memory. Document the deletion path, exercise it on a recurring basis, and verify it.
+- **Log influential reads.** A retrieval that did not change behaviour can be sampled. A retrieval that fed a tool call, approval, or downstream action should be linked to that action's trace.
+- **Test memory under adversarial input.** Plant instruction-shaped content via retrieval or tool output and confirm the write policy refuses it; plant a secret-shaped string and confirm classification blocks it.
+
+## Failure Modes Covered
+
+Direct coverage from the [threat model](../docs/01-threat-model.md):
+
+- **Memory poisoning** — primary coverage; this pattern exists for it.
+- **Credential and token misuse via memory** — classification refuses secrets and the credential broker pattern removes the need to store them.
+- **Context poisoning via memory recall** — provenance and freshness filter, plus instruction-data separation, reduce the chance that poisoned memory drives action.
+- **Monitoring and evaluation blind spots in memory** — write logs, influential read logs, and anomaly detection make memory observable.
+
+Partial coverage:
+
+- **Prompt and instruction attacks** — memory blocks instruction-shaped content from persisting; runtime patterns address single-step instruction handling.
+- **Multi-agent propagation** — namespace isolation reduces cross-agent leakage; broader inter-agent trust controls remain a planned pattern.
 
 ## Evaluation Checks
-- Are memory writes validated and logged?
-- Is sensitive memory encrypted and access-controlled?
-- Are memory access patterns monitored for anomalies?
+
+- Is every memory entry tagged with source, owner, scope, expiry, write reason, classification, and trace identifier? Are untagged entries refused or removed by a recurring sweep?
+- When a synthetic write contains an instruction-shaped string, does the write policy refuse and log the attempt?
+- When a synthetic write contains a secret-shaped string (token, key, identifier), does classification block it?
+- For ten randomly selected memory reads that influenced a tool call, approval, or downstream action, can a reviewer trace the read to the action under the same trace identifier?
+- When an out-of-scope read is requested across namespaces, does the read policy deny and log the attempt?
+- Does the deletion path actually remove the entry from primary storage, replicas, and any derived summaries within a documented target?
+- Do anomaly detectors trigger on synthetic burst, drift, and content-distribution tests?
+
+## Audit Evidence
+
+For each memory event, a reviewer should be able to retrieve under the relevant trace identifier:
+
+- For writes: source, candidate content (or hash where content is sensitive), classification, write policy decision, reviewer approval where required, tags, and store location.
+- For reads: requester, scope, read policy decision, entries returned, filter and source-label transformations, and the action they fed (tool call, approval, downstream change).
+- For deletions: requester, reason, scope of deletion, verification, and confirmation that derived summaries were also addressed.
+- For anomaly events: detector identity, signal, scope quarantined, follow-up review, and resolution.
+
+Audit records should be queryable by namespace, by owner, by classification, by trace identifier, and by anomaly signal.
 
 ## Limitations
-- Encryption and validation may impact performance.
-- Complex memory structures can be hard to audit.
-- Monitoring may generate false positives.
+
+- Classification is imperfect. Deterministic rules miss novel patterns; classifiers produce false positives. The pattern is robust under both because the default is do not store, but teams should expect tuning work.
+- A memory store cannot fix problems upstream. If retrieval already merged untrusted content into reasoning, the memory pattern can only prevent persistence — it cannot undo the in-flight effect.
+- Reviewer-visible memory is only as useful as the review interface. A list of opaque entries does not help users correct or expire memory. Investment in tooling is part of the pattern.
+- Hard expiry can lose useful long-running context. The retention rules should be tuned per category, with longer expiry for low-risk categories and aggressive expiry for high-risk ones.
+- Memory shared across tasks or users requires explicit cross-namespace policy. The default of strict isolation is safer; relaxations should be reviewed.
+- Anomaly detection produces false positives. The escalation should be quarantine and review, not silent drop, so that legitimate patterns can be restored.
+
+## Related
+
+- [docs/01-threat-model.md](../docs/01-threat-model.md) — failure mode 6 (memory poisoning) and failure mode 5 (context poisoning).
+- [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md) — Memory and State Surfaces.
+- [docs/03-agentic-attack-chains.md](../docs/03-agentic-attack-chains.md) — Chain Pattern 3 (tool result to memory persistence).
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — Memory and context layer.
+- Sibling patterns: [secure-agent-runtime.md](secure-agent-runtime.md), [secure-tool-calling.md](secure-tool-calling.md), [credential-and-token-boundaries.md](credential-and-token-boundaries.md), [secure-mcp.md](secure-mcp.md).
+
+Maturity: stable defensive guidance. Last reviewed: 2026-04-29.

--- a/patterns/secure-agent-runtime.md
+++ b/patterns/secure-agent-runtime.md
@@ -1,29 +1,152 @@
 # Secure Agent Runtime
 
 ## Context
-Agentic AI systems execute actions on behalf of users or organizations. The runtime is the environment where agents interpret instructions, call tools, manage memory, and interact with external systems.
+
+The secure agent runtime is the environment in which an agent interprets a goal, draws on context and memory, proposes plans, calls tools, and produces results. It is the surface where language-shaped intent becomes system action.
+
+This pattern applies wherever an agent can:
+
+- Take an open-ended goal and decompose it into steps.
+- Mix instructions and content from different trust levels (system, user, retrieved, tool result, memory, other agents).
+- Call tools, MCP servers, skills, or workflows that affect real systems.
+- Read or write memory that influences future sessions.
+- Act with multi-step autonomy, with or without approval gates.
+
+The runtime is the central place where the four runtime security capabilities described in [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — observe, interpret, constrain, audit — must be glued together. Other patterns (tool calling, MCP, memory, credentials) sit inside or alongside this pattern.
 
 ## Risk
-- Unconstrained agent actions can lead to unauthorized access, data leakage, or unintended consequences.
-- Lack of observability and control increases the risk of undetected failures or malicious behavior.
+
+The runtime is exposed to several composing failure modes:
+
+- **Untrusted instruction can become control.** Retrieved documents, tool results, prior memory, or messages from other agents can carry instructions the user did not approve. If the runtime treats them as control input, the agent can act on goals it was never given.
+- **Unbounded autonomy.** Without explicit stopping conditions, an agent can chain steps until it produces high-impact effects that no single step would have justified.
+- **Late control.** If observation, interpretation, and constraint happen only after a final answer, controls arrive too late to prevent unsafe tool calls, memory writes, or downstream effects.
+- **Missing audit chain.** Without a linked trace from instruction to outcome, the organisation cannot reconstruct what happened, prove what changed, or distinguish a good outcome from a lucky one.
+- **Static configuration.** Runtimes that cannot reload policy, allowlists, or tool catalogues without redeployment leave a window where known-bad behaviour continues.
+
+The runtime is also the layer where most other patterns can be silently bypassed: a tool broker that is not consulted, a credential broker that is skipped, or a memory write that is not classified all happen because the runtime did not enforce them.
 
 ## Recommended Controls
-- Enforce strict boundaries on agent capabilities (tool access, data scope, authority).
-- Implement runtime observability: log actions, tool calls, and context changes.
-- Require explicit approval for sensitive actions or escalations.
-- Use policy engines to constrain agent behavior at runtime.
+
+The runtime should provide explicit, named slots for each control rather than leaving them implicit.
+
+1. **Capability constraints by task.** Bind the agent to an allowlist of tools, MCP servers, memory scopes, and downstream systems for the current task, not for the agent identity in general.
+2. **Source labelling on every input.** System prompts, user prompts, retrieved content, tool results, memory, and inter-agent messages should be tagged with origin and trust level before they enter the reasoning step.
+3. **Instruction-data separation.** Untrusted content should be passed as quoted evidence, not merged into the instruction layer.
+4. **Policy decision before action.** Every proposed tool call, memory write, or downstream action should pass through a policy decision that sees intent, source, identity, and likely impact together.
+5. **Runtime guardrails during execution.** Mid-step checks should compare the current step against the approved task and stop or revise drift.
+6. **Approval gates for sensitive, irreversible, or out-of-scope actions.** Approvals should show source context, parameters, identity, and expected effect — not only a confident final summary.
+7. **Outcome control after action.** Dry runs, previews, post-action validation, rate limits, and rollback paths should sit between the tool runtime and downstream impact.
+8. **End-to-end trace.** Prompt, context, plan, decision, credential, tool call, memory change, approval, and downstream action should be linked under a single trace identifier.
+9. **Hot-reloadable policy.** Allowlists, deny rules, approval thresholds, and capability catalogues should be updatable without redeploying the agent.
+
+## Boundary Diagram
+
+The runtime boundary diagram shows where each control sits between the agent's reasoning step and the action execution surface, and how every step also feeds the audit channel.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant P as Policy
+  participant H as Approval
+  participant G as Guardrail
+  participant X as Action
+  participant L as Audit
+
+  U->>A: Goal and context
+  A->>P: Proposed step
+  alt Allow
+    P->>G: Approve
+    G->>X: Execute
+    X-->>A: Result
+  else Approval needed
+    P->>H: Show evidence
+    H->>G: Approve
+    G->>X: Execute
+  else Deny
+    P-->>A: Deny or revise
+  end
+  P->>L: Trace
+  G->>L: Trace
+  X->>L: Trace
+```
+
+Source: [secure-agent-runtime-boundaries.mmd](../visuals/secure-agent-runtime-boundaries.mmd). A sequence diagram is used because the runtime is a series of step-by-step interactions between named participants (agent, policy, approval, guardrail, action, audit) — the order matters and a flowchart hides it. The diagram makes three things explicit: every step passes through a policy decision before reaching execution, every decision emits an audit trace, and every path has a deny or approval branch in addition to allow.
+
+For the broader system-level reference model, see [visuals/secure-agent-reference-architecture.mmd](../visuals/secure-agent-reference-architecture.mmd).
 
 ## Implementation Notes
-- Integrate audit logging for all agent actions.
-- Use allow/deny lists for tool and data access.
-- Support runtime policy updates without redeploying agents.
+
+These notes are vendor-agnostic. They describe the shape of the controls, not a specific framework.
+
+- **Build the runtime as a pipeline of named stages.** Intake, classification, planning, policy, guardrail, tool broker, credential broker, action, outcome, audit. Each stage should have a clear input, output, decision record, and audit hook. Avoid runtimes where the agent reasoning step calls tools directly without passing through a broker.
+- **Treat the agent reasoning step as untrusted.** The agent can be influenced by retrieved content, so policy and guardrail stages should not rely on the agent's self-report. They should evaluate the proposed step independently.
+- **Pin a task scope at intake.** When a task starts, freeze the allowed tools, data scopes, identity, memory namespaces, and downstream systems. The runtime should refuse silent expansion.
+- **Use a single trace identifier per task** and propagate it through every stage, every tool call, every memory write, and every downstream record. This is what makes incident reconstruction possible.
+- **Separate the policy engine from the agent.** A runtime that asks the agent to evaluate its own policy compliance does not have a policy decision; it has a self-report. Policy decisions should run in code with access to the proposed step, identity, scope, and risk context.
+- **Default deny for unknown tools, capabilities, scopes, and downstream systems.** New capabilities should be added through review, not discovered at runtime.
+- **Make stop conditions explicit.** Maximum steps, maximum cost, maximum data movement, maximum elapsed time, and maximum approval prompts. Reaching a stop condition should always be a logged event.
+- **Persist the plan, not only the final answer.** The proposed step list, revisions, and abandoned branches are part of the audit chain.
+
+## Failure Modes Covered
+
+This pattern is the default integration surface for most failure modes in [docs/01-threat-model.md](../docs/01-threat-model.md). Direct coverage:
+
+- **Prompt and instruction attacks** — through source labelling and instruction-data separation.
+- **Goal hijacking** — through pinned task scope and runtime guardrails that compare each step to the approved goal.
+- **Unsafe autonomous action** — through explicit stop conditions, approval gates, and outcome control.
+- **Monitoring and evaluation blind spots** — through the end-to-end linked trace.
+
+Partial coverage (delegates to a sibling pattern):
+
+- **Tool misuse** — runtime enforces that tool calls go through the broker; specific controls live in [secure-tool-calling.md](secure-tool-calling.md).
+- **Credential and token misuse** — runtime enforces that credentials are brokered, not embedded; controls live in [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+- **Memory poisoning** — runtime enforces that memory writes go through the policy stage; controls live in [memory-security.md](memory-security.md).
+- **MCP, skill, and extension compromise** — runtime enforces that capabilities come from a registry; controls live in [secure-mcp.md](secure-mcp.md).
+- **Multi-agent propagation** — runtime carries trust labels across hand-offs; chain-level controls remain a planned pattern.
 
 ## Evaluation Checks
-- Are all agent actions logged and auditable?
-- Can runtime policies be updated and enforced dynamically?
-- Are sensitive actions gated by approval or escalation?
+
+Use these checks to confirm the runtime is doing the work, not only describing it.
+
+- For ten randomly selected tasks, can a reviewer reconstruct prompt, retrieved context, plan, policy decisions, tool calls, credentials used, memory changes, approvals, outputs, and downstream effects from a single trace identifier?
+- When a planted untrusted instruction tells the agent to call a denied tool, does the runtime deny the call at the policy stage, log the deny reason, and return a revised plan to the agent?
+- When the task scope is pinned to tool A and the agent attempts to call tool B mid-task, does the runtime refuse and record the attempt?
+- Can a security engineer change the allowlist, deny rules, or approval thresholds and see the new policy enforced on the next task without redeployment?
+- For each defined stop condition, is there at least one regression test that exercises it and confirms the runtime halts and logs the stop event?
+- Does the runtime record decisions made by the policy engine separately from the agent's self-reported reasoning?
+
+## Audit Evidence
+
+A reviewer or auditor inspecting one task should be able to retrieve, under a single trace identifier:
+
+- Source-labelled inputs (system, user, retrieved, tool, memory, agent message) with origin and trust level.
+- The proposed plan, plan revisions, and abandoned branches.
+- Each policy decision with matched rule, risk factors, decision, and reason.
+- Each tool call with parameters, broker decision, credential scope, runtime, result, and outcome-control decision.
+- Each memory read and write with provenance, owner, scope, expiry, and reason.
+- Each approval prompt with the evidence shown to the reviewer, the reviewer identity, the decision, and the timestamp.
+- Each downstream change with the business owner, expected effect, observed result, and rollback path where relevant.
+- Stop-condition events and their cause.
+
+Audit records should be queryable by trace identifier, by task, by tool, by credential identity, and by downstream system. This is what makes the runtime governable, not only debuggable.
 
 ## Limitations
-- Overly restrictive controls may reduce agent utility.
-- Observability may introduce performance overhead.
-- Policy complexity can lead to misconfiguration.
+
+- A runtime can enforce the patterns it knows about. It cannot replace the per-pattern controls in [secure-tool-calling.md](secure-tool-calling.md), [secure-mcp.md](secure-mcp.md), [memory-security.md](memory-security.md), and [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+- Strong policy decisions add latency. Teams should expect to tune thresholds, batch evaluations where safe, and accept that high-risk paths cost more.
+- Source labelling is only as good as the retrieval and ingestion code that produces it. A runtime that trusts incorrect labels will still merge untrusted instructions into the control layer.
+- Policy expressed as code is precise but harder to audit by non-engineers. Teams should pair the policy engine with a human-readable summary for reviewers and approvers.
+- Approval fatigue is real. If every action triggers a prompt, reviewers will rubber-stamp. The escalation matrix in [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) is the design tool for keeping approvals informative.
+- The runtime cannot recover from compromised infrastructure underneath it. Host security, supply chain, and identity infrastructure are prerequisites, not parts of this pattern.
+
+## Related
+
+- [docs/01-threat-model.md](../docs/01-threat-model.md) — failure-mode taxonomy.
+- [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md) — surfaces this pattern protects.
+- [docs/03-agentic-attack-chains.md](../docs/03-agentic-attack-chains.md) — chains this pattern interrupts, especially Pattern 1 (instruction influence to tool action) and Pattern 6 (observability gap).
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — control loop and layered control model this pattern implements.
+- Sibling patterns: [secure-tool-calling.md](secure-tool-calling.md), [secure-mcp.md](secure-mcp.md), [memory-security.md](memory-security.md), [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+
+Maturity: stable defensive guidance. Last reviewed: 2026-04-29.

--- a/patterns/secure-mcp.md
+++ b/patterns/secure-mcp.md
@@ -1,29 +1,126 @@
-# Secure MCP (Model Context Protocol)
+# Secure MCP and Capability Governance
 
 ## Context
-The Model Context Protocol (MCP) governs how agentic systems manage context, memory, and tool interactions. Securing MCP is critical for preventing context leakage and unauthorized actions.
+
+The Model Context Protocol (MCP), along with skills, plugins, and packaged extensions, lets an agent host discover and call external capabilities. A capability that is added to the agent's catalogue becomes an authority-bearing boundary: it can read, write, send, modify, deploy, or approve in real systems on behalf of the agent.
+
+This pattern applies wherever an agent host:
+
+- Discovers, installs, or connects to MCP servers, skills, plugins, or extensions.
+- Loads capability descriptions, tool definitions, and parameter schemas from those servers.
+- Forwards prompts, retrieved context, memory, or tool output across the host-to-server boundary.
+- Receives responses that are passed back into the agent's reasoning context or used to drive further tool calls.
+
+The pattern sits between the secure agent runtime and the secure tool calling pattern. The runtime decides that a capability should be invoked; this pattern decides whether that capability is trustworthy enough to be in scope at all, and what crosses the boundary in each direction.
 
 ## Risk
-- Compromised MCP can expose sensitive context or enable unauthorized tool/memory access.
-- Insecure context propagation can lead to privilege escalation or data poisoning.
+
+MCP servers and packaged capabilities concentrate several failure modes from [docs/01-threat-model.md](../docs/01-threat-model.md):
+
+- **Capability sprawl.** Servers are added quickly during prototyping and rarely removed. The effective authority of the agent grows beyond what any single review approved.
+- **Misrepresented capability.** A server's description claims one operation but the implementation does more — for example, a "summarise" tool that also writes to an external store.
+- **Post-install drift.** A server can change after installation. New tools, expanded scopes, or modified schemas can appear without re-review.
+- **Context leakage.** The host forwards prompts, retrieved content, or memory across the host-to-server boundary. Sensitive data can leave the agent's trust boundary unintentionally.
+- **Untrusted instruction injection via responses.** A server can return content that contains instructions the agent treats as control input. This is prompt injection delivered through the capability layer.
+- **Authentication and identity confusion.** Agents may connect to servers without strong server identity verification, or may use a single shared identity for multiple tasks, breaking task-bound authority.
+- **Supply chain weakness.** A capability is only as trustworthy as its source, build process, dependencies, and update channel. A compromise upstream becomes capability-level authority downstream.
 
 ## Recommended Controls
-- Authenticate and authorize all MCP operations.
-- Encrypt sensitive context in transit and at rest.
-- Validate context boundaries before tool/memory access.
-- Monitor MCP activity for anomalies.
+
+The host-side controls below define a trust and policy boundary between the agent host and any MCP server, skill, plugin, or extension.
+
+1. **Capability registry with version pinning.** Every capability that the agent can use is listed in a registry with source, version, schema, capability category, sensitivity scope, owner, and review status. Tasks resolve to specific versions at intake.
+2. **Server authentication.** Verify server identity before sending any request. Use strong identity (mutual TLS, signed manifests, attested origin) where supported.
+3. **Capability scope check.** Each call is checked against the registered capability scope, the task scope, and the user's authority. Out-of-scope calls are denied.
+4. **Context isolation filter.** Outbound requests pass through a filter that strips or summarises content the server does not need to see, based on data sensitivity labels.
+5. **Response validation.** Server responses are schema-validated, source-labelled, and treated as untrusted data before they re-enter the agent's reasoning step. Instruction-shaped content in responses must not redefine goals, allowlists, or memory write policy.
+6. **Review on add and on change.** Adding a capability is a reviewable event. Changes to manifest, scope, schemas, or version trigger re-review and, by default, suspend use until reviewed.
+7. **Default deny for unregistered capabilities.** The host refuses to talk to servers, skills, or extensions that are not in the registry, even if they are reachable.
+8. **Revocation and emergency disable.** Every capability has a documented revocation path and an emergency disable that can take effect across all running tasks.
+9. **Per-capability identity.** Each capability uses a credential issued by the broker for the task and call, not a long-lived shared identity. See [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+10. **Supply chain review.** Capability source, build, dependencies, and update channel are part of the review record. Significant supply chain changes trigger re-review.
+
+## Boundary Diagram
+
+The diagram shows the host process, the trust and policy boundary, and the MCP servers or packaged capabilities. It makes the four key host-side checks explicit: registry and version pinning, server authentication, capability scope check, and context isolation filter — plus response validation on the return path.
+
+```mermaid
+block-beta
+columns 1
+  Host["Agent host: agent reasoning and MCP client"]
+  Boundary["Trust boundary: registry, authentication, scope check, context filter"]
+  Servers["MCP servers and packaged capabilities"]
+  Audit["Observability and audit"]
+```
+
+Source: [secure-mcp-boundaries.mmd](../visuals/secure-mcp-boundaries.mmd). A block diagram is used because the point is the trust boundary between three layers (host, boundary, servers), not the temporal flow. The picture clarifies that capabilities are not transparent extensions of the host: there is a layer of checks between them.
 
 ## Implementation Notes
-- Use strong identity and access management for MCP endpoints.
-- Apply context boundary checks on every operation.
-- Integrate MCP logs with overall observability stack.
+
+- **Treat the registry as authoritative.** If a capability is reachable but not registered, the host should refuse to use it. Discovery does not imply trust.
+- **Pin versions per task.** Resolve the capability version at task intake and bind it for the duration of the task. Mid-task updates should not silently change behaviour.
+- **Sign capability manifests.** Where the ecosystem supports it, require signed manifests and verify signatures against a known publisher list.
+- **Tag forwarded context.** Outbound requests should carry source labels so server-side processing knows what it is receiving. The host should redact or refuse to forward content above the capability's sensitivity scope.
+- **Quarantine instruction-shaped responses.** Patterns like imperatives, role redefinitions, or system-style directives in tool output should be flagged for instruction-data separation. The agent should see them as quoted evidence, not as control.
+- **Catalogue the data each capability sees.** A capability that needs a query but is sent the full prompt history is over-scoped. The context isolation filter should narrow input to what the capability actually requires.
+- **Rotate and revoke.** Maintain a process to rotate capability credentials, revoke compromised ones, and disable a capability across all tasks within minutes of a decision.
+- **Treat skills and plugins like MCP servers.** The same registry, scope check, and review process should apply across all packaged capabilities, regardless of vendor or transport.
+- **Test capability behaviour, not only its description.** Black-box tests should exercise edge cases that the manifest does not document, especially side effects and outbound network calls.
+
+## Failure Modes Covered
+
+Direct coverage from the [threat model](../docs/01-threat-model.md):
+
+- **MCP, skill, and extension compromise** — primary coverage; this pattern exists for it.
+- **Tool misuse via packaged capabilities** — registry, scope check, and per-call review prevent unregistered or out-of-scope capability use.
+- **Context poisoning via capability responses** — response validation, source labelling, and instruction-data separation reduce the chance that responses act as instruction.
+- **Credential and token misuse at the capability boundary** — per-capability identity and broker-issued credentials prevent shared, long-lived authority.
+
+Partial coverage:
+
+- **Prompt and instruction attacks** — covered when delivered through capability responses; instruction attacks delivered through retrieval are addressed by the runtime pattern.
+- **Multi-agent propagation** — covered for agent-to-server hand-offs; agent-to-agent propagation remains a planned pattern.
 
 ## Evaluation Checks
-- Are all MCP operations authenticated and authorized?
-- Is sensitive context encrypted and access-controlled?
-- Are context boundaries enforced and monitored?
+
+- Is every capability the agent can reach listed in the registry with source, version, schema, capability category, sensitivity scope, owner, and review status?
+- Does the host refuse, by default, to talk to a reachable but unregistered server in a synthetic test?
+- When a capability manifest changes between tasks, does the host detect the change and require re-review before further use?
+- For each capability, does the context isolation filter restrict outbound content to what the capability needs?
+- When a server response contains instruction-shaped content, does the agent receive it as quoted evidence rather than as control?
+- Can a capability be revoked across all running tasks within the documented emergency-disable target?
+- For ten randomly selected capability calls, can a reviewer recover server identity verification, capability version, scope check, outbound content sent, response, and validation result?
+
+## Audit Evidence
+
+For each capability invocation, a reviewer should be able to retrieve under the task's trace identifier:
+
+- Capability name, source, registry entry, version pinned, and signature verification result.
+- Server authentication result and method.
+- Capability scope check decision with matched rule and reason.
+- Outbound content after the context isolation filter, including any redactions or refusals.
+- The credential identity and scope issued for the call.
+- Raw and validated server response, source label applied, and any quarantine decisions.
+- Outcome-control decision and downstream effect where applicable.
+- Add, change, and revocation events for the capability across the audit window.
+
+Audit records should be queryable by capability, by version, by task, by identity, and by review status.
 
 ## Limitations
-- Overhead from encryption and boundary checks.
-- Complex context flows may be hard to monitor.
-- False positives in anomaly detection.
+
+- A registry is only as strong as its review process. Rapid prototyping environments often lack the reviewers; in those environments the registry should still default deny, but teams should accept that the bottleneck is review, not technology.
+- Capability behaviour can change after review even when the manifest does not. Black-box testing reduces but does not eliminate this risk.
+- Strong server authentication assumes the ecosystem supports it. Where it does not, teams should treat the capability as lower trust and tighten scope, output validation, and approval gates.
+- Context isolation filters can leak through paraphrase or summarisation. Sensitive content should not be assumed safe just because it has been transformed.
+- Supply chain risk extends beyond the host's control. Even thorough review cannot guarantee no compromise upstream. Revocation speed and audit reach are the compensating controls.
+- Per-capability identity adds operational complexity. Teams should expect work in credential rotation, identity provisioning, and incident response procedures.
+
+## Related
+
+- [docs/01-threat-model.md](../docs/01-threat-model.md) — failure mode 7 (MCP, skill, and extension compromise).
+- [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md) — MCP, skills, and extensions surface; code, MCP, skills, and extensions section.
+- [docs/03-agentic-attack-chains.md](../docs/03-agentic-attack-chains.md) — Chain Pattern 1 and Chain Pattern 4.
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — Tool broker and identity and access layers.
+- Sibling patterns: [secure-agent-runtime.md](secure-agent-runtime.md), [secure-tool-calling.md](secure-tool-calling.md), [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+
+Maturity: stable defensive guidance. Last reviewed: 2026-04-29.

--- a/patterns/secure-tool-calling.md
+++ b/patterns/secure-tool-calling.md
@@ -1,29 +1,141 @@
 # Secure Tool Calling
 
 ## Context
-Agentic systems often call external tools (APIs, scripts, plugins) to perform actions. Tool calls can introduce risk if not properly constrained and monitored.
+
+Tool calling is the moment when language-shaped intent crosses into system action. The agent proposes an operation against an API, function, plugin, MCP server, skill, file, command, or workflow. Whatever the tool reads, writes, sends, deploys, purchases, or approves becomes part of the system's behaviour from that point on.
+
+This pattern applies wherever an agent can:
+
+- Choose between multiple tools for a single goal.
+- Construct tool parameters from a mix of user goal, retrieved content, memory, and prior tool results.
+- Chain tool calls so that the result of one shapes the next.
+- Reach a tool that affects a real system, customer, or financial state — directly or via a workflow.
+
+The pattern works alongside the secure agent runtime: the runtime decides that a tool call should be attempted, and this pattern decides whether and how it should actually execute.
 
 ## Risk
-- Tools may be misused to exfiltrate data, escalate privileges, or perform unintended actions.
-- Insufficient validation of tool inputs/outputs can lead to injection or logic flaws.
+
+Tool calls compose several failure modes from [docs/01-threat-model.md](../docs/01-threat-model.md):
+
+- **Wrong tool, right intent.** The agent picks a tool that can complete the task but exceeds the user's authority, sensitivity scope, or expected blast radius.
+- **Right tool, manipulated parameters.** Parameters are constructed from untrusted retrieved content or memory and silently expand scope (file paths, recipients, recipients lists, account identifiers, queries).
+- **Unsafe composition.** Each individual call is acceptable; the chain is not. A read followed by a summarisation followed by a send can become an exfiltration path.
+- **Unbounded outputs.** Tool results carry untrusted content back into the reasoning step. If the runtime treats them as instruction, the agent's next step is shaped by the tool, not by the user.
+- **Schema drift.** Tools change over time. A runtime that validates against an outdated schema can pass parameters the tool will misinterpret, or block parameters that are now legitimate.
+- **Identity confusion.** Without a credential broker, a tool call may run under a long-lived identity that is not bound to the user, the task, or the approval — making accountability unclear and blast radius unknown.
 
 ## Recommended Controls
-- Restrict tool access by agent role, context, and task.
-- Validate and sanitize all tool inputs and outputs.
-- Monitor and log all tool invocations and results.
-- Implement rate limiting and error handling for tool calls.
+
+Tool calling should be mediated, validated, and bounded — never direct from the agent to the tool runtime.
+
+1. **Tool broker.** All tool calls pass through a broker that knows the task scope, identity, allowlist, schemas, policy, and credential boundary. The agent should never have a direct connection to a tool endpoint.
+2. **Per-task allowlist.** The runtime pins which tools are usable for the current task at intake. The broker rejects calls to tools outside the list.
+3. **Strict schema validation on inputs and outputs.** Parameters are validated against the live schema before execution. Outputs are validated and, where appropriate, redacted, summarised, or quarantined before they re-enter the reasoning step.
+4. **Risk-aware policy decision.** A read-only lookup, a summarisation, and a send are not the same risk class. Policy should evaluate intent, identity, parameters, sensitivity, and downstream system together.
+5. **Composition checks.** The broker should detect risky chains (read sensitive → external send, modify config → deploy, retrieve credentials → call external) and require approval or deny when chains cross policy lines.
+6. **Approval for sensitive tools and chains.** Sensitive, irreversible, or out-of-scope calls require an approval prompt that shows source context, parameters, identity, expected effect, and rollback path.
+7. **Scoped credentials issued by a broker.** Credentials are issued per task, per call, with the narrowest scope and shortest lifetime that completes the operation. See [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+8. **Output handling.** Tool output is treated as untrusted data, not instruction. Source labels accompany output as it re-enters the reasoning context.
+9. **Outcome control.** Dry runs, previews, post-action validation, rate limits, blast-radius limits, and rollback should sit between the tool runtime and downstream impact.
+10. **Rate limits and circuit breakers.** Per-task and per-identity limits on call count, data movement, and downstream cost. Anomalous bursts trigger pause-and-review.
+
+## Boundary Diagram
+
+The flow diagram traces a tool call from agent request through broker, allowlist, schema validation, policy decision, optional approval, credential broker, tool runtime, output validation, and outcome control. Every stage has a deny or revise branch and an audit edge.
+
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant B as Tool broker
+  participant P as Policy
+  participant C as Credential broker
+  participant T as Tool runtime
+  participant L as Audit
+
+  A->>B: Call request
+  B->>B: Allowlist and schema check
+  alt Valid
+    B->>P: Policy decision
+    P->>C: Allow
+    C->>T: Scoped token
+    T-->>B: Result
+    B-->>A: Validated result
+  else Invalid or denied
+    B-->>A: Denied or revised
+  end
+  B->>L: Trace
+  P->>L: Trace
+  C->>L: Trace
+  T->>L: Trace
+```
+
+Source: [secure-tool-calling-flow.mmd](../visuals/secure-tool-calling-flow.mmd). A sequence diagram is used because tool calling is a step-by-step exchange between named participants (agent, broker, policy, credential broker, tool runtime, audit). The diagram is the canonical picture of "the agent never reaches the tool runtime directly".
 
 ## Implementation Notes
-- Use explicit tool whitelists per agent/task.
-- Apply input/output schemas for validation.
-- Integrate tool call monitoring with runtime observability.
+
+- **Define each tool with a security manifest, not only a function signature.** Capability category (read, write, send, modify, delete, deploy, approve, purchase), data sensitivity scope, target systems, identity binding, parameter schema, expected output schema, side-effect class, and revocation contact.
+- **Pin schemas per task.** A task should resolve to a specific tool version and schema at intake. Schema drift should be caught at the broker, not at the tool.
+- **Validate parameters in two passes.** Pass one is structural (does it match the schema?). Pass two is semantic (do values fall inside the task scope, identity, and policy bounds?). Structural validation alone allows scope expansion through legal-but-unintended values.
+- **Treat tool output as data, not instruction.** Output should be quoted, source-labelled, and passed back to the agent as evidence. The runtime should not allow tool output to redefine the goal, allowlist, or memory write policy.
+- **Detect risky chains, not only risky calls.** Maintain a small library of unsafe composition patterns (see Composition Review in [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md)) and check them against the running plan, not only the next single call.
+- **Default deny for unknown parameters.** If a parameter is not present in the schema or the task scope, refuse rather than guess.
+- **Make the broker decision visible to the agent.** When the broker denies or revises a call, the reason should be returned so the agent can plan an alternative — not silently retry.
+- **Per-tool circuit breakers.** A tool that errors or returns malformed output past a threshold should be paused for the task and logged for review.
+- **Per-tool dry-run mode.** Where the target system supports it, prefer dry runs for sensitive calls and require explicit promotion to a real call.
+
+## Failure Modes Covered
+
+Direct coverage from the [threat model](../docs/01-threat-model.md):
+
+- **Tool misuse and unsafe composition** — primary coverage; this pattern exists for it.
+- **Prompt and instruction attacks reaching action** — output handling and instruction-data separation prevent tool output from becoming control.
+- **Goal hijacking that surfaces as a risky tool call** — composition checks and per-task allowlist catch drift that has reached the tool layer.
+- **MCP, skill, and extension compromise at call time** — the broker enforces capability scope; pre-call review lives in [secure-mcp.md](secure-mcp.md).
+- **Unsafe autonomous action** — approval gates, outcome control, and rate limits keep autonomy bounded.
+
+Partial coverage:
+
+- **Credential and token misuse** — broker enforces that calls receive scoped credentials; issuance lives in [credential-and-token-boundaries.md](credential-and-token-boundaries.md).
+- **Context poisoning** — output handling prevents tool results from acting as instruction, but retrieval-side controls live in the (planned) context-poisoning pattern.
 
 ## Evaluation Checks
-- Are tool calls logged and monitored?
-- Are inputs/outputs validated against schemas?
-- Is tool access limited by agent role and context?
+
+- For each tool in the catalogue, is there a security manifest with capability category, sensitivity scope, target system, parameter schema, output schema, and side-effect class?
+- For ten randomly selected tool calls, can a reviewer recover the trace identifier, broker decision, schema version, parameters, policy decision, identity used, output, and outcome-control decision?
+- When an injected untrusted instruction asks the agent to call an out-of-allowlist tool, does the broker deny at the allowlist stage and log the attempt?
+- When a parameter falls outside the task scope (a different account, a sensitive path), does semantic validation catch it before the tool runs?
+- For each defined unsafe composition pattern, does the broker block or escalate when the plan matches?
+- Does tool output enter the agent reasoning step with a source label that prevents it being treated as instruction?
+- Do per-task and per-identity rate limits trigger pause-and-review on synthetic burst tests?
+
+## Audit Evidence
+
+For each tool call, a reviewer should be able to retrieve under the task's trace identifier:
+
+- The proposed call (tool, parameters, intent), the broker's decision (allow, deny, revise, require approval), and the matched policy.
+- The schema version validated against and any validation result (pass, transformed, blocked).
+- The credential identity and scope issued for the call (without exposing the secret value).
+- The tool runtime, raw and post-validated output, and any quarantine or redaction decisions.
+- The outcome-control decision (dry run, preview, executed, blocked, rolled back) with the validating evidence.
+- The downstream system change, business owner where applicable, and rollback path.
+- The composition-check result if the call was part of a risky chain.
+
+Audit records should be queryable by tool, by task, by identity, by downstream system, and by composition pattern.
 
 ## Limitations
-- Excessive restrictions may block legitimate use cases.
-- Schema drift can cause validation failures.
-- Monitoring may not catch all misuse patterns.
+
+- The broker cannot enforce policy on tools that are not registered with it. Discovery, registration, and revocation of tools is a prerequisite — see [secure-mcp.md](secure-mcp.md).
+- Composition detection is heuristic. New unsafe chains will be discovered after deployment; the catalogue should be treated as living.
+- Strict schemas can block legitimate variation. Teams should track false denies and tune schemas through review, not by removing validation.
+- Output validation can be bypassed if downstream code reads the raw tool output instead of the post-validated stream. The runtime should not expose the raw stream.
+- Rate limits and circuit breakers shape behaviour but do not stop a single high-impact call. Approval gates and outcome control remain necessary for irreversible actions.
+- Outcome control depends on the target system supporting previews, dry runs, or rollback. Some systems do not — for those, approval gates should be stricter.
+
+## Related
+
+- [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md) — Tool and Workflow Surfaces, Composition Review.
+- [docs/03-agentic-attack-chains.md](../docs/03-agentic-attack-chains.md) — Chain Pattern 1 (instruction influence to tool action) and Chain Pattern 4 (broad authority to downstream change).
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — Tool broker, policy decision, and outcome control layers.
+- Sibling patterns: [secure-agent-runtime.md](secure-agent-runtime.md), [secure-mcp.md](secure-mcp.md), [credential-and-token-boundaries.md](credential-and-token-boundaries.md), [memory-security.md](memory-security.md).
+
+Maturity: stable defensive guidance. Last reviewed: 2026-04-29.

--- a/visuals/README.md
+++ b/visuals/README.md
@@ -1,31 +1,74 @@
 # Visuals
 
-This section will hold reusable diagrams for explaining agentic execution security. Diagrams should make boundaries, flows, decisions, and control points easier to understand without oversimplifying the security model.
+This section holds reusable diagrams for explaining agentic execution security. Diagrams should make boundaries, lifecycles, decisions, and control points easier to understand without oversimplifying the security model.
 
-Reusable diagrams should be stored as Mermaid source files so they remain readable in GitHub Markdown and portable to the future documentation site.
+Diagrams are stored as Mermaid source files so they remain readable in GitHub Markdown and portable to the future documentation site. Each diagram is also embedded inline in the docs that consume it. The `.mmd` files remain the canonical reusable source.
+
+## Diagram-Syntax Selection Rule
+
+Mermaid syntax should match the communication goal. Default to flowchart only for small decision flows or simple branching logic.
+
+| Goal | Syntax |
+| --- | --- |
+| Layered conceptual architecture | `block-beta` |
+| Step-by-step interactions over time | `sequenceDiagram` |
+| Lifecycle of states with explicit transitions | `stateDiagram-v2` |
+| Taxonomy or conceptual map | `mindmap` |
+| Chronological progression | `timeline` |
+| Small decision branch | `flowchart` |
+
+The full selection rule set is documented at the top of the diagram review notes in this folder.
 
 ## Available Now
 
-- [Progressive Breach Model](progressive-breach-model.mmd) shows the path from untrusted language or data to organisational impact, with control points along the chain.
-- [Agent, Tool, And Memory Attack Flow](agent-tool-memory-attack-flow.mmd) shows how agent reasoning, tools, credentials, memory, approvals, observability, and downstream systems interact.
-- [AI Defense Plane](ai-defense-plane.mmd) shows Discover, Protect, and Govern across agents, tools, memory, authority, downstream action, and assurance evidence.
-- [Secure Agent Reference Architecture](secure-agent-reference-architecture.mmd) shows the control path across intake, agent planning, policy decisions, guardrails, tool and credential brokers, approvals, outcome control, memory, and audit.
+### System-level diagrams
+
+- [Agentic Reasoning And Risk](agentic-reasoning-and-risk.mmd) — `flowchart`. Three input categories converge on agentic reasoning, fan out into three action targets, and compose into risk accumulation. Used at the top of the main README.
+- [Agentic Defence In Depth](agentic-defence-in-depth.mmd) — `mindmap`. Eight defence categories grouped under defence-in-depth, plus the security/performance/coordination trade-off. Used in the main README.
+- [Agentic Execution Landscape](agentic-execution-landscape.mmd) — `block-beta`. Five stacked layers of the agentic execution system, with the control posture wrapping the system.
+- [Failure-Mode Taxonomy](failure-mode-taxonomy.mmd) — `mindmap`. Ten failure modes grouped into six families.
+- [Surface Boundary Map](surface-boundary-map.mmd) — `mindmap`. Twelve attack surfaces grouped into five families.
+- [Progressive Breach Model](progressive-breach-model.mmd) — `timeline`. Eight chronological stages from untrusted input to organisational impact.
+- [Agent, Tool, And Memory Attack Flow](agent-tool-memory-attack-flow.mmd) — `sequenceDiagram`. Step-by-step interactions between user, agent, policy, tool broker, tool, memory, and audit.
+- [AI Defense Plane](ai-defense-plane.mmd) — `block-beta`. Discover, Protect, and Govern as three stacked layers wrapping the agentic execution system.
+- [Secure Agent Reference Architecture](secure-agent-reference-architecture.mmd) — `block-beta`. Seven stacked components of the layered control model.
+
+### Pattern diagrams
+
+- [Pattern Shape](pattern-shape.mmd) — `mindmap`. The standard nine sections every pattern follows, grouped by why, what, how, coverage, caveats.
+- [Secure Engineering Patterns Overview](secure-engineering-patterns-overview.mmd) — `block-beta`. Three layers: runtime, engineering controls, audit.
+- [Secure Agent Runtime Boundaries](secure-agent-runtime-boundaries.mmd) — `sequenceDiagram`. Step-by-step exchange between user, agent, policy, approval, guardrail, action, audit.
+- [Secure Tool Calling Flow](secure-tool-calling-flow.mmd) — `sequenceDiagram`. Step-by-step exchange between agent, tool broker, policy, credential broker, tool runtime, audit.
+- [Secure MCP Boundaries](secure-mcp-boundaries.mmd) — `block-beta`. Three layers: agent host, trust boundary, MCP servers.
+- [Memory Security Flow](memory-security-flow.mmd) — `stateDiagram-v2`. Lifecycle of a memory entry from proposed to expired, blocked, or quarantined.
+- [Credential And Token Boundaries](credential-token-boundaries.mmd) — `stateDiagram-v2`. Lifecycle of a credential from requested to expired, revoked, or denied.
+
+### Navigation, lifecycle, and library-index diagrams
+
+- [Docs Reading Map](docs-reading-map.mmd) — `mindmap`. The field guide grouped into conceptual, composition, engineering, and evidence families.
+- [Chain Library Index](chain-library-index.mmd) — `mindmap`. The ten attack-chain stubs grouped by progressive-breach-model stage.
+- [Case-Study Lifecycle](case-study-lifecycle.mmd) — `stateDiagram-v2`. Lifecycle of an incident case study from detected to closed.
+- [Open-Research Framing](open-research-framing.mmd) — `stateDiagram-v2`. Lifecycle of a research question from failure mode to revision.
 
 ## Planned Coverage
 
 Future visuals will cover:
 
-- Policy decision, tool broker, credential broker, observability, and audit boundaries.
+- Sandboxing and code execution boundaries.
+- Multi-agent communication and delegated authority boundaries.
 
 ## Diagram Standard
 
-Diagrams should:
+Every diagram should:
 
-- Focus on execution boundaries, action flows, escalation paths, observability points, policy decisions, and control points.
-- Be small enough to read without excessive zooming.
-- Avoid decorative complexity that makes the security model harder to inspect.
-- Use concise labels that work in both GitHub and documentation-site rendering.
+- Communicate one idea only.
+- Prefer 4–7 visible components where possible.
+- Use Mermaid syntax that matches the communication goal — see the table above.
+- Use short, concise labels.
+- Avoid unexplained acronyms.
+- Render correctly in GitHub Markdown and MkDocs Material.
+- Have a short caption above the embedded block explaining what it shows and why this syntax was chosen.
 
 ## Use In The Field Guide
 
-Visuals should support the written docs, patterns, and rubrics. A diagram is useful when it helps a reader see how authority, context, tools, memory, controls, and outcomes interact across an agentic system.
+Visuals support the written docs, patterns, and rubrics. A diagram is useful when it helps a reader see how authority, context, tools, memory, controls, and outcomes interact across an agentic system. If a diagram cannot be understood at a glance, it is wrong — split it, simplify it, or change the syntax.

--- a/visuals/agent-tool-memory-attack-flow.mmd
+++ b/visuals/agent-tool-memory-attack-flow.mmd
@@ -1,24 +1,24 @@
-flowchart TD
-    U[User goal] --> A[Agent reasoning and planning]
-    X[Untrusted retrieved content] --> A
-    M[Memory and task state] --> A
-    A --> P[Policy decision]
-    P --> B[Tool broker]
-    P --> R[Human review when needed]
-    R --> B
-    B --> C[Credential broker]
-    C --> T[Tool, MCP server, skill, or workflow]
-    B --> T
-    T --> D[Downstream system]
-    T --> O[Tool result]
-    O --> A
-    A --> M
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant P as Policy
+  participant B as Tool broker
+  participant T as Tool or MCP
+  participant M as Memory
+  participant L as Audit
 
-    A -.-> L[Observability and audit]
-    P -.-> L
-    B -.-> L
-    C -.-> L
-    T -.-> L
-    M -.-> L
-    R -.-> L
-    D -.-> L
+  U->>A: Goal
+  M-->>A: Retrieved memory
+  A->>P: Proposed plan
+  alt Allowed
+    P->>B: Allow
+    B->>T: Scoped call
+    T-->>A: Result
+  else Denied
+    P-->>A: Deny or revise
+  end
+  A->>M: Memory write
+  P->>L: Trace
+  B->>L: Trace
+  T->>L: Trace
+  M->>L: Trace

--- a/visuals/agentic-defence-in-depth.mmd
+++ b/visuals/agentic-defence-in-depth.mmd
@@ -1,0 +1,33 @@
+mindmap
+  root((Defence in depth))
+    Environment engineering
+      Refusal tokens
+    Secure protocols
+      Commitments
+      Zero-knowledge proofs
+      Multi-party computation
+    Monitoring and firewalls
+      Layered
+      Dynamic
+    Containment and isolation
+      Sandboxing
+      Trusted execution environments
+      Zero-trust
+    Attribution
+      Provenance
+      Causal inference
+    Cross-cutting
+      Multimodality
+      Chain-of-thought
+      Tool use
+    Adversarial testing
+      Benchmarks
+      Simulations
+    Sociotechnical defences
+      Standards
+      Governance
+      Transparency
+    Trade-offs
+      Security
+      Performance
+      Coordination

--- a/visuals/agentic-execution-landscape.mmd
+++ b/visuals/agentic-execution-landscape.mmd
@@ -1,0 +1,7 @@
+block-beta
+columns 1
+  Posture["Control posture: Observe → Interpret → Constrain → Audit"]
+  Inputs["Inputs: instructions, retrieved context, memory"]
+  Agent["Agent reasoning"]
+  Action["Action layer: tools, MCP, code, credentials, approvals"]
+  Outcome["Downstream systems and assurance evidence"]

--- a/visuals/agentic-reasoning-and-risk.mmd
+++ b/visuals/agentic-reasoning-and-risk.mmd
@@ -1,0 +1,19 @@
+flowchart TB
+    UP["User prompt"]
+    RD["Retrieved context"]
+    SR["System rules"]
+    AR["<b>Agentic reasoning</b><br/>Goals emerge at runtime;<br/>static review cannot inspect them"]
+    IK["Internal knowledge"]
+    EA["External APIs"]
+    OT["Operational tools"]
+    Risk["<b>Risk accumulation</b><br/>Each step passes a local check;<br/>the composed outcome may exceed approved scope"]
+
+    UP --> AR
+    RD --> AR
+    SR --> AR
+    AR -->|permitted step| IK
+    AR -->|permitted step| EA
+    AR -->|permitted step| OT
+    IK --> Risk
+    EA --> Risk
+    OT --> Risk

--- a/visuals/ai-defense-plane.mmd
+++ b/visuals/ai-defense-plane.mmd
@@ -1,38 +1,7 @@
-flowchart TB
-    subgraph System[Agentic execution system]
-        Agents[Agents and workflows]
-        Context[Prompts context and memory]
-        Tools[Tools MCP servers and skills]
-        Authority[Credentials and delegated authority]
-        Actions[Downstream actions]
-    end
-
-    subgraph Plane[AI Defense Plane]
-        Discover[Discover inventory ownership and flows]
-        Protect[Protect runtime decisions and controls]
-        Govern[Govern authority evidence and accountability]
-    end
-
-    Discover --> Protect
-    Protect --> Govern
-
-    Discover -.-> Agents
-    Discover -.-> Context
-    Discover -.-> Tools
-    Discover -.-> Authority
-    Discover -.-> Actions
-
-    Protect -.-> Context
-    Protect -.-> Tools
-    Protect -.-> Authority
-    Protect -.-> Actions
-
-    Govern -.-> Authority
-    Govern -.-> Actions
-    Govern -.-> Evidence[Audit and assurance evidence]
-
-    Agents --> Context
-    Context --> Tools
-    Tools --> Authority
-    Authority --> Actions
-    Actions --> Evidence
+block-beta
+columns 3
+  Discover["Discover\nInventory and ownership"]
+  Protect["Protect\nRuntime decisions and controls"]
+  Govern["Govern\nAuthority, evidence, accountability"]
+  System["Agentic execution system: agents, context, tools, memory, authority, downstream"]:3
+  Evidence["Audit and assurance evidence"]:3

--- a/visuals/case-study-lifecycle.mmd
+++ b/visuals/case-study-lifecycle.mmd
@@ -1,0 +1,10 @@
+stateDiagram-v2
+  [*] --> Detected
+  Detected --> Reconstructed : trace and surface review
+  Reconstructed --> Mapped : align to attack chain
+  Mapped --> Analysed : controls failed and would have helped
+  Analysed --> PatternUpdated : update or extend pattern
+  Analysed --> EvalAdded : add evaluation or red-team test
+  PatternUpdated --> Closed
+  EvalAdded --> Closed
+  Closed --> [*]

--- a/visuals/chain-library-index.mmd
+++ b/visuals/chain-library-index.mmd
@@ -1,0 +1,19 @@
+mindmap
+  root((Chain library))
+    Influence
+      Prompt injection to tool misuse
+      Poisoned retrieved context
+      Hidden instruction in document ingestion
+    Action
+      Code execution side effects
+    Authority
+      Credential overreach
+    State
+      Memory poisoning
+    Capability
+      Unsafe MCP or tool extension
+    Propagation
+      Agent-to-agent contamination
+    Governance
+      Fake approval loop
+      Workflow automation abuse

--- a/visuals/credential-token-boundaries.mmd
+++ b/visuals/credential-token-boundaries.mmd
@@ -1,0 +1,12 @@
+stateDiagram-v2
+  [*] --> Requested
+  Requested --> Denied : scope too broad
+  Requested --> Issued : task-bound and short-lived
+  Issued --> InUse : tool call
+  InUse --> Issued : continue
+  Issued --> Expired : lifetime ends
+  InUse --> Revoked : task ends or breach signal
+  Issued --> Revoked : task ends or breach signal
+  Expired --> [*]
+  Revoked --> [*]
+  Denied --> [*]

--- a/visuals/docs-reading-map.mmd
+++ b/visuals/docs-reading-map.mmd
@@ -1,0 +1,15 @@
+mindmap
+  root((Field guide))
+    Conceptual
+      00 Landscape
+      01 Threat model
+      02 Surfaces
+    Composition
+      03 Attack chains
+      04 Defence architecture
+    Engineering
+      07 Patterns
+      patterns/ files
+    Evidence
+      09 Case studies
+      10 Open questions

--- a/visuals/failure-mode-taxonomy.mmd
+++ b/visuals/failure-mode-taxonomy.mmd
@@ -1,0 +1,18 @@
+mindmap
+  root((Failure modes))
+    Influence
+      Prompt injection
+      Goal hijacking
+      Context poisoning
+    Authority
+      Tool misuse
+      Credential misuse
+    State
+      Memory poisoning
+    Capability
+      MCP and extension compromise
+    Propagation
+      Multi-agent propagation
+    Outcome
+      Unsafe autonomous action
+      Monitoring blind spots

--- a/visuals/memory-security-flow.mmd
+++ b/visuals/memory-security-flow.mmd
@@ -1,0 +1,16 @@
+stateDiagram-v2
+  [*] --> Proposed
+  Proposed --> Classified : classify
+  Classified --> Blocked : secret or instruction
+  Classified --> ReviewPending : needs review
+  ReviewPending --> Blocked : rejected
+  ReviewPending --> Tagged : approved
+  Classified --> Tagged : auto-allow
+  Tagged --> Stored
+  Stored --> Retrieved : read policy passes
+  Retrieved --> Stored
+  Stored --> Quarantined : anomaly detected
+  Stored --> Expired : expiry or deletion
+  Expired --> [*]
+  Blocked --> [*]
+  Quarantined --> [*]

--- a/visuals/open-research-framing.mmd
+++ b/visuals/open-research-framing.mmd
@@ -1,0 +1,9 @@
+stateDiagram-v2
+  [*] --> FailureMode
+  FailureMode --> Pattern : map to existing pattern
+  Pattern --> Gap : identify control gap
+  Gap --> Question : frame research question
+  Question --> Eval : propose evaluation
+  Eval --> Evidence : produce results
+  Evidence --> Revision : new pattern or revision
+  Revision --> [*]

--- a/visuals/pattern-shape.mmd
+++ b/visuals/pattern-shape.mmd
@@ -1,0 +1,16 @@
+mindmap
+  root((Pattern shape))
+    Why
+      Context
+      Risk
+    What
+      Recommended controls
+      Boundary diagram
+    How
+      Implementation notes
+    Coverage
+      Failure modes covered
+      Evaluation checks
+      Audit evidence
+    Caveats
+      Limitations

--- a/visuals/progressive-breach-model.mmd
+++ b/visuals/progressive-breach-model.mmd
@@ -1,17 +1,10 @@
-flowchart LR
-    A[Untrusted language or data] --> B[Intent or goal compromise]
-    B --> C[Tool, workflow, or code action]
-    C --> D[Credential or delegated authority use]
-    D --> E[Memory, state, or context change]
-    E --> F[Propagation across agents or systems]
-    F --> G[Unsafe autonomous action]
-    G --> H[Organisational impact]
-
-    A -.-> A1[Source labelling]
-    B -.-> B1[Goal alignment check]
-    C -.-> C1[Tool and policy decision]
-    D -.-> D1[Credential broker]
-    E -.-> E1[Memory and state review]
-    F -.-> F1[Origin and trust labels]
-    G -.-> G1[Approval and outcome control]
-    H -.-> H1[Audit and incident review]
+timeline
+  title Progressive breach progression
+  Influence : Untrusted language or data
+  Intent : Goal compromise
+  Action : Tool, workflow, or code
+  Authority : Credential or delegated authority
+  State : Memory or context change
+  Propagation : Across agents or systems
+  Autonomy : Unsafe autonomous action
+  Impact : Organisational impact

--- a/visuals/secure-agent-reference-architecture.mmd
+++ b/visuals/secure-agent-reference-architecture.mmd
@@ -1,35 +1,9 @@
-flowchart TD
-    Goal[User goal or delegated task] --> Intake[Instruction and context intake]
-    Sources[External sources and retrieved data] --> Intake
-    Memory[Memory and task state] --> Intake
-    Intake --> Agent[Agent planning and reasoning]
-
-    Agent --> Policy[Policy decision]
-    Policy -->|allow or revise| Guardrail[Runtime guardrail]
-    Policy -->|require review| Approval[Human approval gate]
-    Policy -->|deny| Denied[Denied or revised action]
-    Approval --> Guardrail
-
-    Guardrail --> ToolBroker[Tool broker]
-    ToolBroker --> CredentialBroker[Credential broker]
-    CredentialBroker --> ToolRuntime[Tool MCP skill workflow or code]
-    ToolBroker --> ToolRuntime
-    ToolRuntime --> Outcome[Outcome control]
-    Outcome --> Downstream[Downstream system]
-    ToolRuntime --> Result[Tool result]
-    Result --> Agent
-
-    Agent --> MemoryDecision[Memory write decision]
-    MemoryDecision --> Memory
-
-    Intake -.-> Audit[Observability and audit]
-    Agent -.-> Audit
-    Policy -.-> Audit
-    Guardrail -.-> Audit
-    Approval -.-> Audit
-    ToolBroker -.-> Audit
-    CredentialBroker -.-> Audit
-    ToolRuntime -.-> Audit
-    Outcome -.-> Audit
-    Downstream -.-> Audit
-    MemoryDecision -.-> Audit
+block-beta
+columns 1
+  Inputs["Inputs: user goal, retrieved context, memory"]
+  Agent["Agent reasoning"]
+  Decision["Policy decision and approval gate"]
+  Brokers["Tool broker and credential broker"]
+  Execution["Tool runtime, MCP, or workflow"]
+  Outcome["Outcome control and downstream system"]
+  Audit["Observability and audit"]

--- a/visuals/secure-agent-runtime-boundaries.mmd
+++ b/visuals/secure-agent-runtime-boundaries.mmd
@@ -1,0 +1,25 @@
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant P as Policy
+  participant H as Approval
+  participant G as Guardrail
+  participant X as Action
+  participant L as Audit
+
+  U->>A: Goal and context
+  A->>P: Proposed step
+  alt Allow
+    P->>G: Approve
+    G->>X: Execute
+    X-->>A: Result
+  else Approval needed
+    P->>H: Show evidence
+    H->>G: Approve
+    G->>X: Execute
+  else Deny
+    P-->>A: Deny or revise
+  end
+  P->>L: Trace
+  G->>L: Trace
+  X->>L: Trace

--- a/visuals/secure-engineering-patterns-overview.mmd
+++ b/visuals/secure-engineering-patterns-overview.mmd
@@ -1,0 +1,5 @@
+block-beta
+columns 1
+  Runtime["Secure agent runtime: intake, policy, guardrail, approval"]
+  Engineering["Secure tool calling | Secure MCP | Credential and token boundaries | Memory security"]
+  Audit["Observability and audit"]

--- a/visuals/secure-mcp-boundaries.mmd
+++ b/visuals/secure-mcp-boundaries.mmd
@@ -1,0 +1,6 @@
+block-beta
+columns 1
+  Host["Agent host: agent reasoning and MCP client"]
+  Boundary["Trust boundary: registry, authentication, scope check, context filter"]
+  Servers["MCP servers and packaged capabilities"]
+  Audit["Observability and audit"]

--- a/visuals/secure-tool-calling-flow.mmd
+++ b/visuals/secure-tool-calling-flow.mmd
@@ -1,0 +1,23 @@
+sequenceDiagram
+  participant A as Agent
+  participant B as Tool broker
+  participant P as Policy
+  participant C as Credential broker
+  participant T as Tool runtime
+  participant L as Audit
+
+  A->>B: Call request
+  B->>B: Allowlist and schema check
+  alt Valid
+    B->>P: Policy decision
+    P->>C: Allow
+    C->>T: Scoped token
+    T-->>B: Result
+    B-->>A: Validated result
+  else Invalid or denied
+    B-->>A: Denied or revised
+  end
+  B->>L: Trace
+  P->>L: Trace
+  C->>L: Trace
+  T->>L: Trace

--- a/visuals/surface-boundary-map.mmd
+++ b/visuals/surface-boundary-map.mmd
@@ -1,0 +1,19 @@
+mindmap
+  root((Attack surfaces))
+    Inputs
+      Instructions
+      Context and retrieval
+    Action
+      Tools
+      MCP and extensions
+      Code and automation
+      Credentials
+    State
+      Memory
+    Governance
+      Approvals
+      Policy decisions
+      Observability
+    Cross-system
+      Multi-agent
+      Downstream


### PR DESCRIPTION
## Add agentic defence patterns and visual maps

Adds secure engineering pattern guidance, attack-chain stubs, Mermaid diagrams, and navigation updates connecting threat models, attack surfaces, defence architecture, and implementation controls.