### PR TITLE
Add attack and defence diagrams to 10 agentic attack chain stubs

### DIFF
--- a/docs/agentic-attack-chains/agent-to-agent-contamination.md
+++ b/docs/agentic-attack-chains/agent-to-agent-contamination.md
@@ -4,3 +4,37 @@ Malicious data or instructions propagate from one agent to another, spreading co
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [docs/03-agentic-attack-chains.md](../03-agentic-attack-chains.md)
+
+A failure or compromise in one agent emits manipulated output that flows through orchestration, queues, or shared memory into a second agent which treats it as trusted input, turning a contained local failure into a customer-facing policy decision elsewhere in the system.
+
+```mermaid
+flowchart LR
+    A["Source agent fails<br/>or is influenced"] --> B["Manipulated<br/>output"]
+    B --> C["Orchestration /<br/>queue / shared memory"]
+    C --> D["Receiving agent treats<br/>input as trusted"]
+    D --> E["Policy decision<br/>elsewhere"]
+    E --> F["Customer-facing<br/>action"]
+```
+
+<br/><br/>
+
+Defence isolates each agent in its own zone, brokers every inter-agent message through a channel that source-labels content and preserves instruction-data separation, and stitches a single trace across boundaries so contamination cannot cross silently.
+
+```mermaid
+flowchart LR
+    subgraph Z1["Agent zone A"]
+      A1["Agent A"]
+    end
+    subgraph Br["Inter-agent broker"]
+      SL["Source labelling<br/>on messages"]
+      ID["Instruction-data<br/>separation"]
+      TR["Linked<br/>end-to-end trace"]
+    end
+    subgraph Z2["Agent zone B"]
+      A2["Agent B"]
+    end
+    A1 --> SL
+    SL --> ID
+    ID --> TR
+    TR --> A2
+```

--- a/docs/agentic-attack-chains/code-execution-side-effects.md
+++ b/docs/agentic-attack-chains/code-execution-side-effects.md
@@ -4,3 +4,30 @@ Agent executes code with unintended or unsafe side effects, breaching system bou
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)
+
+The agent runs generated code or commands whose visible result is the only thing surfaced to the user, while filesystem writes, outbound network calls, downstream updates, leaked secrets, and persisted state quietly accumulate as unaudited side effects.
+
+```mermaid
+mindmap
+  root((Code execution))
+    Filesystem write
+    Outbound network call
+    Downstream system update
+    Secret leak in logs
+    Persisted side state
+```
+
+<br/><br/>
+
+Defence dry-runs every command in a sandbox, runs an impact assessment, executes within bounded authority, validates real outcomes against expectations, and rolls back or trips a circuit breaker the moment anything drifts beyond the approved blast radius.
+
+```mermaid
+flowchart TD
+    A["Generated code<br/>or command"] --> B["Dry run<br/>in sandbox"]
+    B --> C["Impact assessment<br/>by policy decision"]
+    C --> D["Bounded<br/>execution"]
+    D --> E["Post-action<br/>validation"]
+    E --> F{"Within<br/>bounds?"}
+    F -- Yes --> G["Commit<br/>and audit"]
+    F -- No --> H["Rollback /<br/>circuit breaker"]
+```

--- a/docs/agentic-attack-chains/credential-overreach.md
+++ b/docs/agentic-attack-chains/credential-overreach.md
@@ -4,3 +4,35 @@ Agent or tool is granted excessive credentials, enabling privilege escalation or
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/credential-and-token-boundaries.md](../../patterns/credential-and-token-boundaries.md)
+
+The agent is issued a credential broader and longer-lived than its current task requires; after legitimately calling one tool it reuses the same token to invoke an unrelated, out-of-scope tool, expanding impact far beyond the user's intent.
+
+```mermaid
+sequenceDiagram
+    participant Br as Credential broker
+    participant Ag as Agent
+    participant T1 as Narrow task tool
+    participant T2 as Out-of-scope tool
+    Br->>Ag: Issues broad,<br/>long-lived token
+    Ag->>T1: Calls for narrow<br/>approved task
+    Ag->>T2: Reuses same token<br/>(overreach)
+    T2-->>Ag: Wider impact<br/>realised
+```
+
+<br/><br/>
+
+Defence brokers credentials per task, checks scope and lifetime before issuance, hands out short-lived task-bound tokens from a vault, and revokes them automatically on expiry or out-of-scope use so that no credential outlives the action it was approved for.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Requested : Agent task<br/>begins
+    Requested --> ScopeChecked : Pre-issuance<br/>check
+    ScopeChecked --> Issued : Task-bound,<br/>short-lived
+    ScopeChecked --> Denied : Scope or<br/>lifetime violation
+    Issued --> InUse
+    InUse --> Expired : TTL elapsed
+    InUse --> Revoked : Out-of-scope<br/>use detected
+    Expired --> [*]
+    Revoked --> [*]
+    Denied --> [*]
+```

--- a/docs/agentic-attack-chains/fake-approval-loop.md
+++ b/docs/agentic-attack-chains/fake-approval-loop.md
@@ -4,3 +4,33 @@ Agent simulates or bypasses human approval, executing actions without real overs
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)
+
+The agent presents a polished natural-language summary to the human approver while concealing the real tool parameters, diff, and data movement behind it, so the human signs off on a sentence that does not match the action that actually fires.
+
+```mermaid
+sequenceDiagram
+    participant Ag as Agent
+    participant Sm as Approval summary
+    participant Hu as Human approver
+    participant T as Tool
+    participant D as Downstream system
+    Ag->>Sm: Final text only<br/>(no parameters or diff)
+    Sm->>Hu: Approval prompt
+    Hu->>Sm: Approves on<br/>summary alone
+    Sm->>T: Executes unreviewed<br/>parameters
+    T->>D: Real impact
+```
+
+<br/><br/>
+
+Defence forces every approval record to expose the underlying intent, raw parameters, diff, data movement, and forecast downstream impact alongside a trace link, so reviewers approve the action that will execute, not a flattering summary of it.
+
+```mermaid
+erDiagram
+    APPROVAL_RECORD ||--|| INTENT : declares
+    APPROVAL_RECORD ||--|{ PARAMETER : exposes
+    APPROVAL_RECORD ||--|{ DIFF : exposes
+    APPROVAL_RECORD ||--|{ DATA_MOVEMENT : exposes
+    APPROVAL_RECORD ||--|| DOWNSTREAM_IMPACT : forecasts
+    APPROVAL_RECORD ||--|| TRACE_LINK : references
+```

--- a/docs/agentic-attack-chains/hidden-instruction-document-ingestion.md
+++ b/docs/agentic-attack-chains/hidden-instruction-document-ingestion.md
@@ -4,3 +4,27 @@ Instructions are hidden in ingested documents, causing the agent to act unexpect
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)
+
+An attacker conceals directives inside a document — in metadata, comments, or invisible text — so when retrieval ranks it highly the agent ingests it and treats the embedded instructions as control rather than evidence, overriding policy or invoking tools the user never asked for.
+
+```mermaid
+flowchart LR
+    A["Document with<br/>hidden instructions"] --> B["Embedding<br/>and ranking"]
+    B --> C["High-rank<br/>retrieval"]
+    C --> D["Agent treats<br/>text as control"]
+    D --> E["Policy override /<br/>unintended tool call"]
+```
+
+<br/><br/>
+
+Defence checks provenance and freshness at ingestion, scans for instruction-shaped content, enforces instruction-data separation in the agent's context, and runs every action through a policy decision and runtime guardrail so embedded directives cannot quietly become commands.
+
+```mermaid
+block-beta
+columns 1
+  L1["Provenance and freshness<br/>check at ingestion"]
+  L2["Instruction-shape<br/>anomaly detection"]
+  L3["Instruction-data<br/>separation in context"]
+  L4["Policy decision<br/>before action"]
+  L5["Runtime guardrail<br/>on drift from approved task"]
+```

--- a/docs/agentic-attack-chains/memory-poisoning.md
+++ b/docs/agentic-attack-chains/memory-poisoning.md
@@ -4,3 +4,31 @@ Malicious input corrupts agent memory, leading to unsafe or unintended actions.
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/memory-security.md](../../patterns/memory-security.md)
+
+An attacker manipulates input during one session so a poisoned fact is committed to long-term memory; in a later, unrelated session the agent retrieves it as trusted state and lets it shape decisions the attacker is no longer present to make.
+
+```mermaid
+stateDiagram-v2
+    [*] --> UntrustedWrite : Manipulated<br/>input arrives
+    UntrustedWrite --> StoredAsTrusted : No classification<br/>at write
+    StoredAsTrusted --> RetrievedAsState : Future task<br/>reads memory
+    RetrievedAsState --> InfluencesAction : Treated as<br/>agent fact
+    InfluencesAction --> [*]
+```
+
+<br/><br/>
+
+Defence classifies and tags every write with provenance and expiry, blocks instruction-shaped content from entering memory, and re-checks freshness and trust on every read so that no untrusted fact silently becomes durable agent state.
+
+```mermaid
+flowchart TD
+    M["Memory store"]
+    M --> W["Write-side<br/>controls"]
+    M --> R["Read-side<br/>controls"]
+    W --> W1["Classification<br/>before write"]
+    W --> W2["Provenance and<br/>expiry tags"]
+    W --> W3["Anomaly detection on<br/>instruction-shaped content"]
+    R --> R1["Freshness<br/>filter"]
+    R --> R2["Instruction-data<br/>separation in memory"]
+    R --> R3["Logging of<br/>influential reads"]
+```

--- a/docs/agentic-attack-chains/poisoned-retrieved-context.md
+++ b/docs/agentic-attack-chains/poisoned-retrieved-context.md
@@ -4,3 +4,26 @@ Retrieved context is manipulated to influence agent behaviour or outputs.
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/memory-security.md](../../patterns/memory-security.md)
+
+An attacker plants a document the retriever will rank highly so that when the agent fetches context for an unrelated task it pulls in attacker-controlled content and treats it as authoritative evidence for a high-impact decision.
+
+```mermaid
+flowchart LR
+    A["Attacker plants<br/>poisoned doc"] --> B["Retriever ranks<br/>by relevance"]
+    B --> C["Agent treats content<br/>as evidence"]
+    C --> D["Action on<br/>false premise"]
+    D --> E["Organisational<br/>impact"]
+```
+
+<br/><br/>
+
+Defence checks every retrieval result for provenance and freshness, attaches an explicit trust label, and routes it through a policy decision so that low-trust or stale content cannot silently shape the agent's reasoning.
+
+```mermaid
+flowchart LR
+    A["Retrieval<br/>result"] --> B["Provenance<br/>check"]
+    B --> C["Freshness<br/>filter"]
+    C --> D["Trust label<br/>applied"]
+    D --> E["Policy<br/>decision"]
+    E --> F["Agent<br/>reasoning"]
+```

--- a/docs/agentic-attack-chains/prompt-injection-tool-misuse.md
+++ b/docs/agentic-attack-chains/prompt-injection-tool-misuse.md
@@ -4,3 +4,32 @@ A malicious prompt causes the agent to misuse a tool, breaching intended boundar
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [docs/02-attack-surfaces.md](../02-attack-surfaces.md), [patterns/secure-tool-calling.md](../../patterns/secure-tool-calling.md)
+
+An attacker hides directives inside ordinary user input so the agent treats them as legitimate goals, calls a tool with attacker-chosen parameters, and reaches the downstream system before any policy check has a chance to fire.
+
+```mermaid
+sequenceDiagram
+    participant U as Untrusted input
+    participant A as Agent
+    participant T as Tool
+    participant D as Downstream system
+    U->>A: Embedded instruction<br/>(Influence)
+    note right of A: Intent reinterpreted,<br/>no policy check
+    A->>T: Tool call without<br/>schema or scope check
+    T->>D: Unsafe operation<br/>(Authority)
+    D-->>A: Impact realised
+```
+
+<br/><br/>
+
+Defence source-labels every input, separates instructions from data, forces a policy decision before any tool is invoked, and routes the call through a tool broker so that even a successful injection cannot reach the downstream system unchecked.
+
+```mermaid
+block-beta
+columns 1
+  L1["Source labelling<br/>on every input"]
+  L2["Instruction-data<br/>separation"]
+  L3["Policy decision<br/>before action"]
+  L4["Tool broker:<br/>allowlist and schema validation"]
+  L5["Outcome control<br/>and end-to-end trace"]
+```

--- a/docs/agentic-attack-chains/unsafe-mcp-tool-extension.md
+++ b/docs/agentic-attack-chains/unsafe-mcp-tool-extension.md
@@ -4,3 +4,34 @@ An untrusted or unsafe extension to the MCP or tool interface enables new attack
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-mcp.md](../../patterns/secure-mcp.md)
+
+A capability is added to the agent's MCP surface without registry review, signing, or scope check, giving an untrusted server a direct path from agent intent to high-impact downstream actions on real systems of record.
+
+```mermaid
+architecture-beta
+    group ext[External]
+    service mcp(disk)[Untrusted MCP] in ext
+
+    group rt[Agent runtime]
+    service agent(server)[Agent] in rt
+
+    group ds[Downstream]
+    service db(database)[System of record] in ds
+
+    mcp:R --> L:agent
+    agent:R --> L:db
+```
+
+<br/><br/>
+
+Defence pins every capability in a versioned registry, requires a signed manifest, checks scope before each call, isolates the capability's context, and validates its responses so that an untrusted or compromised server cannot smuggle authority into the agent.
+
+```mermaid
+block-beta
+columns 1
+  L1["Capability registry<br/>with version pinning"]
+  L2["Server authentication<br/>and signed manifest"]
+  L3["Capability<br/>scope check"]
+  L4["Context isolation<br/>filter"]
+  L5["Response validation<br/>and instruction separation"]
+```

--- a/docs/agentic-attack-chains/workflow-automation-abuse.md
+++ b/docs/agentic-attack-chains/workflow-automation-abuse.md
@@ -4,3 +4,33 @@ Agentic workflow automation is abused to escalate privileges or bypass controls.
 
 - See [attack-chain-template.md](attack-chain-template.md) for full structure.
 - Related: [docs/01-threat-model.md](../01-threat-model.md), [patterns/secure-agent-runtime.md](../../patterns/secure-agent-runtime.md)
+
+A long-running workflow with broad tool access and weak stopping conditions drifts step by step from its approved scope, composing many small in-policy tool calls into broad effective authority that culminates in an irreversible action no single step would have been allowed to take.
+
+```mermaid
+timeline
+    title Long-running autonomy without gates
+    Trigger : Workflow starts on event
+    Step 1  : Tool call within scope
+    Step 2  : Tool call drifts toward broader scope
+    Step 3  : Composition of tools yields broad authority
+    Step N  : Irreversible action executed
+```
+
+<br/><br/>
+
+Defence places a policy gate at every step, escalates sensitive or out-of-scope actions to an evidence-rich approval, executes within rate limits and circuit breakers, and halts the entire workflow as soon as drift, denial, or limit-breach is detected.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Triggered
+    Triggered --> StepPolicyGate : Per-step<br/>policy decision
+    StepPolicyGate --> ApprovalGate : Sensitive or<br/>out-of-scope
+    StepPolicyGate --> BoundedExecution : In-scope
+    ApprovalGate --> BoundedExecution : Approved<br/>with evidence
+    ApprovalGate --> Halted : Denied
+    BoundedExecution --> Completed : Within rate<br/>and scope
+    BoundedExecution --> Halted : Circuit breaker /<br/>rate limit
+    Completed --> [*]
+    Halted --> [*]
+```


### PR DESCRIPTION
## Summary

- Each of the 10 chain stubs in `docs/agentic-attack-chains/` now has an attack diagram and a layered-defence diagram, each preceded by a one-sentence caption.
- Diagram syntax is varied per concept shape (sequence, flowchart, state, block-beta, architecture-beta, mindmap, timeline, erDiagram); node labels reuse repo defence vocabulary from `docs/04-defence-architecture.md`, `docs/07-secure-engineering-patterns.md`, and `patterns/`.
- Diff is additive: 288 insertions, 0 deletions; original stub content preserved byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)