### PR TITLE
Add v1 evaluation framework for rubrics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,3 +32,4 @@ What would you like reviewers to check most closely?
 - [ ] No unnecessary operational exploit detail is included.
 - [ ] No copied source material is included when a summary and link would be enough.
 - [ ] No generated outputs, built documentation, logs, traces, screenshots, reports, exports, or local artefacts are included.
+- [ ] If this PR adds a new resource, case study, or benchmark, a corresponding scoresheet under `rubrics/scoresheets/` is included (see [rubrics/README.md](../rubrics/README.md)).

--- a/.github/workflows/scoresheet-check.yml
+++ b/.github/workflows/scoresheet-check.yml
@@ -1,0 +1,54 @@
+name: Scoresheet Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  scoresheet-check:
+    name: Verify scoresheet presence for new tracked artefacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check that new tracked artefacts have a scoresheet
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE=$(git merge-base origin/main HEAD)
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE"...HEAD || true)
+
+          # Tracked artefact additions:
+          # - new chain stubs under docs/agentic-attack-chains/ (excluding README and template)
+          # - new files under future case-studies/ or benchmarks/ top-level directories (forward-compatible)
+          tracked=$(printf '%s\n' "$ADDED" \
+            | grep -E '^(docs/agentic-attack-chains|case-studies|benchmarks)/[^/]+\.md$' \
+            | grep -v -E '/(README|attack-chain-template)\.md$' \
+            || true)
+
+          # Scoresheet additions: any new file under rubrics/scoresheets/ except its README.
+          scoresheets=$(printf '%s\n' "$ADDED" \
+            | grep -E '^rubrics/scoresheets/[^/]+\.md$' \
+            | grep -v -E '/README\.md$' \
+            || true)
+
+          if [ -n "$tracked" ] && [ -z "$scoresheets" ]; then
+            echo "::error::This PR adds the following tracked artefact(s) without a corresponding scoresheet under rubrics/scoresheets/:"
+            printf '%s\n' "$tracked" | sed 's/^/  - /'
+            echo ""
+            echo "Pick the right rubric in rubrics/README.md, copy its scoresheet template, score the artefact, and add the scoresheet to this PR."
+            echo "See rubrics/scoresheets/README.md for the naming convention and worked examples."
+            exit 1
+          fi
+
+          if [ -n "$tracked" ]; then
+            echo "Tracked artefact(s) added with corresponding scoresheet(s):"
+            printf '%s\n' "$tracked" | sed 's/^/  - /'
+            echo "Scoresheet(s) added:"
+            printf '%s\n' "$scoresheets" | sed 's/^/  - /'
+          else
+            echo "No new tracked artefacts in this PR; scoresheet check skipped."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -223,7 +223,5 @@ __marimo__/
 # Project scaffolding
 specs/
 
-# Deferred local drafts
-rubrics/README.md
 
 

--- a/rubrics/README.md
+++ b/rubrics/README.md
@@ -1,0 +1,75 @@
+# Rubrics
+
+This directory holds the assessment layer of the field guide. Where [docs/](../docs/) explains *what* the threats and defences are, and [patterns/](../patterns/) explains *how* to engineer the controls, the rubrics here define *what counts as good* — the bar a resource, benchmark, case study, or system must clear before it earns its place in the repository or in production.
+
+## Evaluation principle
+
+Four tools, each answering a different question. Use the right one for the job.
+
+| Tool | Answers | When to reach for it | Example in this repo |
+|---|---|---|---|
+| **Rubric** | "Is this *good*?" Multi-criterion human judgement against anchored descriptors. | Subjective, multi-faceted quality calls where reasonable reviewers might disagree until the criteria are made explicit. | Should we add this benchmark to the catalogue? Is this case study credible enough to publish? |
+| **Test suite** | "Does it do X under condition Y?" Behavioural verification with deterministic pass/fail. | When the question has a defined right answer and inputs can be controlled. | Does the tool broker reject calls that fail schema validation? Does the credential broker refuse to issue a token outside the requested scope? |
+| **Assertion** | "Has this invariant been violated?" A condition that must hold at every step. | When something must *never* happen, regardless of intent or path. | Did any tool call execute without a logged policy decision? Did memory ever store an instruction-shaped string? |
+| **LLM-as-judge** | "Did this output regress against a known reference?" | Tightly-scoped regression where ground-truth checks are hard to express but a stable reference output exists. | Did this agent's response drift from approved task framing across 200 trials? |
+
+The rubrics in this directory address the first row only. **If a criterion can be automated, it should be a CI assertion, not a rubric line.** The rubrics' job is the part of evaluation that requires human judgement; everything else belongs in tests, assertions, or scoped LLM-as-judge regressions.
+
+## When to use each rubric
+
+| Rubric | Scores | Used at |
+|---|---|---|
+| [agent-security-readiness-rubric.md](agent-security-readiness-rubric.md) | A real or proposed agentic AI system | Pre-production review, architecture sign-off, periodic re-assessment |
+| [benchmark-quality-rubric.md](benchmark-quality-rubric.md) | A third-party benchmark before citing or recommending it | Before adding to [docs/06-benchmarks.md](../docs/06-benchmarks.md) |
+| [case-study-rubric.md](case-study-rubric.md) | An incident or scenario case study | Before publishing in [docs/09-incident-case-studies.md](../docs/09-incident-case-studies.md) |
+| [resource-quality-rubric.md](resource-quality-rubric.md) | An external resource (standard, framework, paper, tool) or an internal field-guide resource | Before adding to the awesome list or accepting a substantial doc contribution |
+
+## Anchored scoring at a glance
+
+Every rubric uses the same four-level scale per criterion:
+
+- **0 — Absent.** The criterion is not addressed at all.
+- **1 — Inadequate.** Addressed superficially; would not survive review.
+- **2 — Adequate.** Meets the bar for inclusion or production-readiness; minor gaps acceptable.
+- **3 — Strong.** Sets the bar; could be used as a model for others.
+
+Each rubric file contains the per-criterion prose for what 0, 1, 2, and 3 look like for that specific criterion.
+
+## Aggregation and verdict
+
+- Five criteria × three points = **15** maximum raw score.
+- **Floor rule:** any criterion at 0 fails the rubric outright; two or more criteria at ≤1 also fail.
+- **Verdict bands** (rubric files may tighten these):
+  - **≥ 12 with no criterion below 2** → *Strong; include or green-light.*
+  - **9–11 with no criterion below 2** → *Acceptable with reviewer-noted caveats.*
+  - **< 9, or any criterion at 0–1** → *Reject or rework.*
+
+## How to apply a rubric
+
+1. Open the relevant rubric file and read the per-criterion anchors.
+2. Copy the scoresheet template at the bottom of that rubric file into a new file under [scoresheets/](scoresheets/), following the naming convention in [scoresheets/README.md](scoresheets/README.md).
+3. Score each criterion 0–3 with a short evidence quote or pointer in the *Evidence* column.
+4. Compute the aggregate, apply the floor rule, and record the verdict.
+5. For substantial decisions, score with two raters and adjudicate disagreements before recording the verdict.
+
+## Inter-rater agreement
+
+Each rubric carries a placeholder for inter-rater agreement (κ ≥ 0.6 target on a small pilot). These are pilot-pending until two raters score a sample of artefacts and Cohen's κ is computed. Rubrics should be treated as *guidance* until a pilot has produced calibration evidence; once calibrated, they become *load-bearing* for inclusion decisions.
+
+## Worked examples
+
+The [scoresheets/](scoresheets/) directory contains worked examples showing each rubric applied to a real artefact. Read these before scoring your first artefact — they show what level of evidence is expected per cell.
+
+## Status
+
+This is a v1 framework. Known gaps:
+
+- No worked example yet for [agent-security-readiness-rubric.md](agent-security-readiness-rubric.md); deferred until a candidate system is selected for assessment.
+- Inter-rater pilots not yet run; targets stated, results pending.
+- LLM-as-judge harness referenced in the principle table but not yet built; out of scope for v1.
+
+## Related
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — editorial standards every scored artefact must also satisfy.
+- [docs/05-red-teaming-and-evaluation.md](../docs/05-red-teaming-and-evaluation.md) — broader evaluation context (planned coverage).
+- [docs/04-defence-architecture.md](../docs/04-defence-architecture.md) — the layered control model the readiness rubric maps onto.

--- a/rubrics/agent-security-readiness-rubric.md
+++ b/rubrics/agent-security-readiness-rubric.md
@@ -8,3 +8,97 @@ A rubric for evaluating the security readiness of agentic AI systems.
 - Memory and context security
 - Policy and approval enforcement
 - Evidence of evaluation and red teaming
+
+## Anchored level descriptors
+
+Each criterion is scored 0–3 against the anchors below.
+
+### Observability and auditability
+
+- **0 — Absent.** No structured logging of agent decisions, tool calls, or context. Failures cannot be reconstructed.
+- **1 — Inadequate.** Some logging exists but is unstructured or partial. The chain from input to outcome cannot be reconstructed end-to-end.
+- **2 — Adequate.** Structured logs cover inputs, policy decisions, tool calls, and outcomes. An end-to-end trace can be reconstructed for a sampled task. Retention is defined.
+- **3 — Strong.** Linked traces from influence to outcome are available for every task. Decision logs, approval records, and tool-call payloads are queryable, retained per policy, and used routinely in incident response and review.
+
+### Tool and credential boundary controls
+
+- **0 — Absent.** Agent has unscoped tool access; credentials are long-lived and broad.
+- **1 — Inadequate.** Some allowlisting or scoping exists but is inconsistent; credentials are reused across tasks or persisted in agent context.
+- **2 — Adequate.** A tool broker mediates calls with per-task allowlist and schema validation. Credentials are issued task-bound from a vault and have a defined lifetime. Out-of-scope use is detected.
+- **3 — Strong.** All tool calls flow through a broker with risk-aware policy decisions and composition checks. Credentials are short-lived, task-bound, vault-backed, and never exposed to the agent. Revocation paths are tested.
+
+### Memory and context security
+
+- **0 — Absent.** Memory and retrieved context are accepted without provenance, classification, or freshness checks.
+- **1 — Inadequate.** Some controls exist on writes or reads but not both; instruction-shaped content can enter memory unnoticed.
+- **2 — Adequate.** Writes are classified and tagged with provenance and expiry; reads apply freshness and instruction-data separation; memory contents are reviewer-visible.
+- **3 — Strong.** Write and read controls are layered with anomaly detection on instruction-shaped content; logs of influential reads exist; retention and deletion rules are enforced and audited.
+
+### Policy and approval enforcement
+
+- **0 — Absent.** No policy decision precedes tool calls; sensitive actions execute without human review.
+- **1 — Inadequate.** Policies exist on paper but are not enforced at runtime; approval gates surface only the agent's natural-language summary.
+- **2 — Adequate.** A policy decision precedes every tool call, considering source trust, data sensitivity, and impact. Approval gates show parameters, diffs, and forecast impact for sensitive or irreversible actions.
+- **3 — Strong.** Policy is hot-reloadable and version-controlled. Approval records carry intent, parameters, diff, data movement, downstream impact, and a trace link. Runtime guardrails detect drift mid-execution.
+
+### Evidence of evaluation and red teaming
+
+- **0 — Absent.** No evaluation or adversarial testing has been performed.
+- **1 — Inadequate.** Ad-hoc manual testing only; no documented threat scenarios or coverage of agentic chains.
+- **2 — Adequate.** A test suite covers behavioural verification of key controls; at least one adversarial exercise has been run against the system; results are documented.
+- **3 — Strong.** Continuous evaluation is wired into CI; chain-aligned red-team scenarios run on a defined cadence; regressions block release; results are tracked and acted upon.
+
+## Scoring procedure
+
+1. **Raters.** For pre-production review and architecture sign-off, score with two raters drawn from different functions (security engineer + AI engineer is a typical pair). Adjudicate disagreements of two or more points before recording the verdict.
+2. **Evidence.** Each score must cite concrete evidence — a trace ID, a config file path, a runbook link, an evaluation report, or an absence ("no logging configured for tool calls; verified by inspection of logging.yaml").
+3. **Cadence.** Score on initial production sign-off and re-score on material change to runtime, tools, credentials, memory layer, or policy.
+4. **Recording.** File the completed scoresheet under [scoresheets/](scoresheets/) using the naming convention `agent-readiness-{system-slug}.md`.
+
+## Aggregation rule
+
+- Maximum raw score: **15** (5 criteria × 3).
+- **Floor rule:** any criterion at 0 fails the rubric outright; two or more criteria at ≤ 1 also fail.
+- **Verdict bands:**
+  - **≥ 13 with no criterion below 2** → *Production-ready.*
+  - **10–12 with no criterion below 2** → *Acceptable with reviewer-noted caveats and a remediation plan.*
+  - **< 10, or any criterion at 0–1** → *Not ready; rework before re-scoring.*
+
+The bar is stricter than the cross-rubric default because production sign-off is load-bearing.
+
+## Scoresheet template
+
+```markdown
+---
+rubric: agent-security-readiness-rubric.md
+artefact: <system name>
+artefact_version: <commit SHA, release tag, or assessment date>
+scored_by: <names>
+scored_on: <YYYY-MM-DD>
+rater_count: <1 or 2-with-adjudication>
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Observability and auditability | | | |
+| Tool and credential boundary controls | | | |
+| Memory and context security | | | |
+| Policy and approval enforcement | | | |
+| Evidence of evaluation and red teaming | | | |
+
+## Aggregate
+
+- Raw total: __ / 15
+- Floor rule triggered: <yes/no, which criterion>
+- Verdict: <Production-ready / Acceptable with caveats / Not ready>
+
+## Reviewer commentary
+
+<2–4 sentences on what's strongest, what's weakest, and what would lift the score.>
+```
+
+## Inter-rater agreement
+
+Pilot pending. Target Cohen's κ ≥ 0.6 on a 12-system pilot before this rubric is treated as load-bearing for production sign-off. Until then, scores are guidance and disagreements should be resolved through discussion rather than averaged.

--- a/rubrics/benchmark-quality-rubric.md
+++ b/rubrics/benchmark-quality-rubric.md
@@ -8,3 +8,96 @@ A rubric for assessing the quality of agentic AI security benchmarks.
 - Evidence requirements
 - Transparency of limitations
 - Reproducibility
+
+## Anchored level descriptors
+
+Each criterion is scored 0–3 against the anchors below.
+
+### Scope and relevance to agentic systems
+
+- **0 — Absent.** Tests only single-turn model responses; no notion of tools, memory, multi-step planning, or delegated authority.
+- **1 — Inadequate.** Touches one agentic surface superficially (e.g., generic prompt-injection on chat without tool use).
+- **2 — Adequate.** Covers at least one agentic chain end-to-end (input → reasoning → tool call → outcome) with realistic tool surfaces.
+- **3 — Strong.** Covers multiple chains from the agentic threat taxonomy (tool misuse, credential overreach, memory poisoning, multi-agent contamination, code-execution side effects, etc.) with realistic adversarial scenarios and clear mapping to attack surfaces.
+
+### Methodological soundness
+
+- **0 — Absent.** No method described; results cannot be interpreted.
+- **1 — Inadequate.** Method described but key choices (task selection, scoring, baselines) are unjustified.
+- **2 — Adequate.** Method is documented with justified choices, baselines, and acknowledged limitations. Independent re-running would yield comparable results.
+- **3 — Strong.** Pre-registered or peer-reviewed method with explicit threats-to-validity, ablations, and statistical treatment of variance. Replication has been demonstrated externally.
+
+### Evidence requirements
+
+- **0 — Absent.** Reports headline numbers only; no per-task results, prompts, or traces.
+- **1 — Inadequate.** Aggregate results published; underlying prompts, tools, or per-task scores are not shareable.
+- **2 — Adequate.** Per-task results, prompts, and tool definitions are published; traces or transcripts are available for inspection.
+- **3 — Strong.** All artefacts are versioned and reproducible: prompts, tool implementations, per-task results, and full traces. Results across model/agent versions are tracked over time.
+
+### Transparency of limitations
+
+- **0 — Absent.** No discussion of limitations; results presented as definitive.
+- **1 — Inadequate.** Boilerplate caveat only ("results may not generalise").
+- **2 — Adequate.** Specific known limitations are listed (coverage gaps, language scope, threat-model assumptions, contamination risk).
+- **3 — Strong.** Limitations are quantified where possible, threat-model boundaries are explicit, and the benchmark documents what it does *not* claim to measure.
+
+### Reproducibility
+
+- **0 — Absent.** Cannot be reproduced from public artefacts.
+- **1 — Inadequate.** Partial artefacts; dependency or runtime details missing; non-deterministic without seeds.
+- **2 — Adequate.** Public, runnable artefact with pinned dependencies; seeded runs produce comparable results within a documented variance.
+- **3 — Strong.** One-command reproduction with containerised runtime, pinned dependencies, recorded seeds, and documented variance bounds. CI runs the benchmark on each release.
+
+## Scoring procedure
+
+1. **Raters.** Single rater for routine catalogue review; two raters with adjudication for any benchmark a published recommendation will rest on.
+2. **Evidence.** Cite a section, table, or repository path for each score. For per-task evidence, link to the artefact location (e.g., the GitHub directory containing per-task transcripts).
+3. **Recency.** Re-score when the benchmark publishes a new version or when the agentic threat landscape it claims to cover materially shifts.
+4. **Recording.** File the completed scoresheet under [scoresheets/](scoresheets/) using the naming convention `benchmark-{benchmark-slug}.md`.
+
+## Aggregation rule
+
+- Maximum raw score: **15** (5 criteria × 3).
+- **Floor rule:** any criterion at 0 fails the rubric outright; two or more criteria at ≤ 1 also fail.
+- **Verdict bands:**
+  - **≥ 12 with no criterion below 2** → *Recommended; cite confidently.*
+  - **9–11 with no criterion below 2** → *Cite with caveats noted alongside the entry.*
+  - **< 9, or any criterion at 0–1** → *Do not cite as authoritative; treat as exploratory only.*
+
+## Scoresheet template
+
+```markdown
+---
+rubric: benchmark-quality-rubric.md
+artefact: <benchmark name>
+artefact_version: <release tag or commit SHA>
+artefact_url: <link to benchmark repository or paper>
+scored_by: <name or handle>
+scored_on: <YYYY-MM-DD>
+rater_count: <1 or 2-with-adjudication>
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Scope and relevance to agentic systems | | | |
+| Methodological soundness | | | |
+| Evidence requirements | | | |
+| Transparency of limitations | | | |
+| Reproducibility | | | |
+
+## Aggregate
+
+- Raw total: __ / 15
+- Floor rule triggered: <yes/no, which criterion>
+- Verdict: <Recommended / Cite with caveats / Do not cite>
+
+## Reviewer commentary
+
+<2–4 sentences on what's strongest, what's weakest, and what would lift the score.>
+```
+
+## Inter-rater agreement
+
+Pilot pending. Target Cohen's κ ≥ 0.6 on a 12-benchmark pilot before this rubric is treated as load-bearing for catalogue inclusion. Until then, scores are guidance and disagreements should be resolved through discussion.

--- a/rubrics/case-study-rubric.md
+++ b/rubrics/case-study-rubric.md
@@ -8,3 +8,95 @@ A rubric for evaluating incident and scenario case studies in agentic AI securit
 - Impact and controls discussion
 - Evidence and references
 - Maturity and generalizability
+
+## Anchored level descriptors
+
+Each criterion is scored 0–3 against the anchors below.
+
+### Clarity of what happened and why it matters
+
+- **0 — Absent.** The narrative is missing or incoherent; a reader cannot tell what occurred.
+- **1 — Inadequate.** A surface narrative exists but key actors, sequence, or outcome are unclear.
+- **2 — Adequate.** A reader can summarise the incident in two sentences after a single read; the *why it matters* is stated explicitly.
+- **3 — Strong.** Narrative is precise, sequenced, and anchored in concrete artefacts; the *why it matters* is tied to a named threat model entry or attack chain.
+
+### Attack surface and exploit path analysis
+
+- **0 — Absent.** No surfaces or paths identified.
+- **1 — Inadequate.** Surfaces named but not connected into a path; or path described without referencing surfaces.
+- **2 — Adequate.** Attack surfaces are named using repo-native vocabulary (from [docs/02-attack-surfaces.md](../docs/02-attack-surfaces.md)) and connected into a path that maps to one of the chains in [docs/agentic-attack-chains/](../docs/agentic-attack-chains/).
+- **3 — Strong.** Each step in the exploit path is anchored to a specific surface, the chain is named explicitly, and preconditions and trust boundaries are called out at each transition.
+
+### Impact and controls discussion
+
+- **0 — Absent.** Impact and controls are not discussed.
+- **1 — Inadequate.** Impact stated vaguely; controls listed generically without tying to the failure path.
+- **2 — Adequate.** Impact is concrete (data, authority, downstream system, regulatory exposure). Controls are named from [patterns/](../patterns/) and tied to the specific points in the path where they would have interrupted the chain.
+- **3 — Strong.** Impact is quantified or scoped; controls discussion identifies *which* control at *which* point would have prevented or contained the chain, and acknowledges any control whose absence was the root cause.
+
+### Evidence and references
+
+- **0 — Absent.** No references; no indication whether the case is real, hypothetical, or composite.
+- **1 — Inadequate.** Sparse references; evidence level not stated; reader cannot tell what is grounded vs. inferred.
+- **2 — Adequate.** Maturity and evidence levels are explicitly stated (real / plausible / hypothetical; well-evidenced / supported / inferred). External references support the technical claims.
+- **3 — Strong.** Every load-bearing claim is referenced; the evidence level per claim is explicit; provenance is clear; the case can be independently verified.
+
+### Maturity and generalisability
+
+- **0 — Absent.** Cannot be generalised; reads as anecdote.
+- **1 — Inadequate.** One-off; no defensive lesson abstracted.
+- **2 — Adequate.** Generalises into a defensive lesson tied to at least one chain and one pattern; useful for teams beyond the original context.
+- **3 — Strong.** Sets a teaching example: the lesson is portable across stacks, the failure mode is named, and the case is suitable for inclusion in red-team scenario libraries or onboarding material.
+
+## Scoring procedure
+
+1. **Raters.** Single rater for routine review; two raters with adjudication when the case is being added to the canonical case-study set in [docs/09-incident-case-studies.md](../docs/09-incident-case-studies.md).
+2. **Evidence.** Cite the case-study fields directly (e.g., *"What happened: ..." section reads ..."*). For external references, paste the URL or DOI in the *Evidence* column.
+3. **Editorial check.** Verify the case follows the [CONTRIBUTING.md](../CONTRIBUTING.md) editorial standard — calm tone, evidence-led, no unnecessary operational exploit detail.
+4. **Recording.** File the completed scoresheet under [scoresheets/](scoresheets/) using the naming convention `case-study-{case-slug}.md`.
+
+## Aggregation rule
+
+- Maximum raw score: **15** (5 criteria × 3).
+- **Floor rule:** any criterion at 0 fails the rubric outright; two or more criteria at ≤ 1 also fail. *Evidence and references* at ≤ 1 is a hard fail because case studies without evidence cannot be cited safely.
+- **Verdict bands:**
+  - **≥ 12 with no criterion below 2 and Evidence ≥ 2** → *Publish.*
+  - **9–11 with no criterion below 2** → *Publish with reviewer-noted caveats; flag the weakest dimension for a future revision.*
+  - **< 9, or floor rule triggered** → *Do not publish; rework or drop.*
+
+## Scoresheet template
+
+```markdown
+---
+rubric: case-study-rubric.md
+artefact: <case study title>
+artefact_path: <path to case study, e.g. docs/09-incident-case-studies.md#tool-misuse-leading-to-credential-leak>
+scored_by: <name or handle>
+scored_on: <YYYY-MM-DD>
+rater_count: <1 or 2-with-adjudication>
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Clarity of what happened and why it matters | | | |
+| Attack surface and exploit path analysis | | | |
+| Impact and controls discussion | | | |
+| Evidence and references | | | |
+| Maturity and generalisability | | | |
+
+## Aggregate
+
+- Raw total: __ / 15
+- Floor rule triggered: <yes/no, which criterion>
+- Verdict: <Publish / Publish with caveats / Do not publish>
+
+## Reviewer commentary
+
+<2–4 sentences on what's strongest, what's weakest, and what would lift the score.>
+```
+
+## Inter-rater agreement
+
+Pilot pending. Target Cohen's κ ≥ 0.6 on a 12-case pilot before this rubric is treated as load-bearing for canonical case-study inclusion. Until then, scores are guidance and disagreements should be resolved through discussion.

--- a/rubrics/resource-quality-rubric.md
+++ b/rubrics/resource-quality-rubric.md
@@ -8,3 +8,97 @@ A rubric for assessing the quality of resources included in the agentic AI secur
 - Clarity and editorial quality
 - Recency and ongoing relevance
 - Transparency of limitations
+
+## Anchored level descriptors
+
+Each criterion is scored 0–3 against the anchors below. The rubric applies to both external resources (standards, papers, tools) and internal field-guide resources (docs pages, chain stubs, patterns).
+
+### Relevance to agentic AI security
+
+- **0 — Absent.** Generic AI or general security material with no agentic relevance.
+- **1 — Inadequate.** Touches one aspect tangentially (e.g., LLM safety in general) without addressing tools, memory, credentials, multi-agent flow, or delegated authority.
+- **2 — Adequate.** Directly addresses one or more agentic surfaces or chains; useful to a reader of this field guide.
+- **3 — Strong.** Centrally about agentic execution security; addresses multiple surfaces or chains and earns a place in a reading path for the topic.
+
+### Evidence-based claims
+
+- **0 — Absent.** Claims are unsupported, speculative, or promotional.
+- **1 — Inadequate.** Some claims are supported, others are assertions without evidence; reader cannot tell which is which.
+- **2 — Adequate.** Load-bearing claims are sourced (citation, dataset, code, or named example). Distinction between empirical claim and informed opinion is clear.
+- **3 — Strong.** Every load-bearing claim is referenced or demonstrated; methodology behind quantitative claims is explicit; opinions are flagged as such.
+
+### Clarity and editorial quality
+
+- **0 — Absent.** Unstructured, jargon-heavy, or unreadable; key terms undefined.
+- **1 — Inadequate.** Readable but disorganised; key concepts buried; tone inconsistent with the field guide's editorial standard.
+- **2 — Adequate.** Well-structured, precise prose; key terms defined; tone is calm and evidence-led; British English (or established AI Defense Plane spelling) where the resource is internal.
+- **3 — Strong.** Exceptionally clear; lands its argument quickly; cross-references its own taxonomy; could be used as an editorial model.
+
+### Recency and ongoing relevance
+
+- **0 — Absent.** Material describes systems or threats that have been superseded; recommendations are obsolete.
+- **1 — Inadequate.** More than two years old without re-publication; primary surfaces or threats it addresses have shifted.
+- **2 — Adequate.** Within two years, or older but still describes durable architecture or principles; last-checked date recorded for external resources.
+- **3 — Strong.** Current within twelve months, or older but maintained and re-published; explicitly tracks changes in the agentic threat landscape.
+
+### Transparency of limitations
+
+- **0 — Absent.** Presents conclusions as universal; no caveats, scope statement, or threat model.
+- **1 — Inadequate.** Generic disclaimer only; no specific limitation or scope boundary stated.
+- **2 — Adequate.** Specific limitations and scope boundaries stated (model classes, tool surfaces, deployment contexts not covered).
+- **3 — Strong.** Limitations are quantified or worked through with examples; the resource explicitly states what it does *not* claim and where its conclusions stop applying.
+
+## Scoring procedure
+
+1. **Raters.** Single rater for awesome-list inclusion; two raters with adjudication for resources that the field guide will rely on heavily (e.g., a pattern document, a foundational standard cited from multiple chains).
+2. **Evidence.** Cite a section, page, or paragraph for each score. For external resources, record the URL and the *Last-checked date* required by [CONTRIBUTING.md](../CONTRIBUTING.md).
+3. **Editorial check.** Verify [CONTRIBUTING.md](../CONTRIBUTING.md) editorial standards: British English (where internal), calm tone, no copied source material, no unnecessary operational exploit detail, no overstated maturity.
+4. **Recording.** File the completed scoresheet under [scoresheets/](scoresheets/) using the naming convention `resource-{slug}.md`.
+
+## Aggregation rule
+
+- Maximum raw score: **15** (5 criteria × 3).
+- **Floor rule:** any criterion at 0 fails the rubric outright; two or more criteria at ≤ 1 also fail. *Evidence-based claims* at ≤ 1 is a hard fail.
+- **Verdict bands:**
+  - **≥ 12 with no criterion below 2** → *Include in awesome list / cite from field guide.*
+  - **9–11 with no criterion below 2** → *Include with reviewer-noted caveats alongside the entry.*
+  - **< 9, or floor rule triggered** → *Do not include; rework if internal, drop if external.*
+
+## Scoresheet template
+
+```markdown
+---
+rubric: resource-quality-rubric.md
+artefact: <resource title>
+artefact_url_or_path: <URL for external; repo path for internal>
+artefact_version: <publication date or commit SHA>
+last_checked: <YYYY-MM-DD>  # for external resources only
+scored_by: <name or handle>
+scored_on: <YYYY-MM-DD>
+rater_count: <1 or 2-with-adjudication>
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Relevance to agentic AI security | | | |
+| Evidence-based claims | | | |
+| Clarity and editorial quality | | | |
+| Recency and ongoing relevance | | | |
+| Transparency of limitations | | | |
+
+## Aggregate
+
+- Raw total: __ / 15
+- Floor rule triggered: <yes/no, which criterion>
+- Verdict: <Include / Include with caveats / Do not include>
+
+## Reviewer commentary
+
+<2–4 sentences on what's strongest, what's weakest, and what would lift the score.>
+```
+
+## Inter-rater agreement
+
+Pilot pending. Target Cohen's κ ≥ 0.6 on a 12-resource pilot before this rubric is treated as load-bearing for awesome-list inclusion. Until then, scores are guidance and disagreements should be resolved through discussion.

--- a/rubrics/scoresheets/README.md
+++ b/rubrics/scoresheets/README.md
@@ -1,0 +1,49 @@
+# Scoresheets
+
+This directory holds completed scoresheets — one file per artefact that has been scored against a rubric. Each scoresheet records the rubric used, the artefact, the scores per criterion with evidence, and the verdict.
+
+## How to add a scoresheet
+
+1. Pick the rubric that fits the artefact (see [../README.md](../README.md) for the *when to use each* table).
+2. Open that rubric file and copy the **Scoresheet template** block at the bottom.
+3. Create a new file in this directory using the naming convention below.
+4. Fill in the YAML front-matter, score each criterion 0–3 with a short evidence quote, compute the aggregate, apply the floor rule, and record the verdict.
+5. For substantial decisions, score with two raters and adjudicate disagreements before recording the verdict.
+
+## Naming convention
+
+`{rubric-prefix}-{artefact-slug}.md`
+
+| Rubric | Prefix | Example filename |
+|---|---|---|
+| [agent-security-readiness-rubric.md](../agent-security-readiness-rubric.md) | `agent-readiness-` | `agent-readiness-internal-research-agent.md` |
+| [benchmark-quality-rubric.md](../benchmark-quality-rubric.md) | `benchmark-` | `benchmark-agentdojo.md` |
+| [case-study-rubric.md](../case-study-rubric.md) | `case-study-` | `case-study-tool-misuse-credential-leak.md` |
+| [resource-quality-rubric.md](../resource-quality-rubric.md) | `resource-` | `resource-owasp-llm-top-10.md` |
+
+The artefact slug is lowercase, hyphen-separated, and short enough that the filename remains readable. For internal artefacts, derive the slug from the file path or title; for external artefacts, derive from the publisher and resource name.
+
+## Worked examples in this directory
+
+These four scoresheets are the canonical worked examples. New contributors should read at least one before scoring their first artefact.
+
+| File | Rubric | Artefact |
+|---|---|---|
+| [resource-chain-prompt-injection-tool-misuse.md](resource-chain-prompt-injection-tool-misuse.md) | resource-quality | Internal: [docs/agentic-attack-chains/prompt-injection-tool-misuse.md](../../docs/agentic-attack-chains/prompt-injection-tool-misuse.md) |
+| [resource-owasp-llm-top-10.md](resource-owasp-llm-top-10.md) | resource-quality | External: OWASP Top 10 for LLM Applications |
+| [case-study-tool-misuse-credential-leak.md](case-study-tool-misuse-credential-leak.md) | case-study | Internal: example case study in [docs/09-incident-case-studies.md](../../docs/09-incident-case-studies.md) |
+| [benchmark-agentdojo.md](benchmark-agentdojo.md) | benchmark-quality | External: AgentDojo |
+
+A worked example for [agent-security-readiness-rubric.md](../agent-security-readiness-rubric.md) is deferred to v2 and will be added when a candidate system is selected for assessment.
+
+## Editorial standards
+
+Scoresheets are public-facing artefacts. They must follow [CONTRIBUTING.md](../../CONTRIBUTING.md):
+
+- Calm, evidence-led tone — no hype, no fear-based language.
+- No unnecessary operational exploit detail.
+- No copied source material when a summary and a link are enough.
+
+## Status of scores
+
+A score recorded here is the verdict at the *artefact_version* recorded in the front-matter. When a scored artefact materially changes (a benchmark releases a new version, a doc page is rewritten, a system's runtime is replaced), re-score and add a new dated scoresheet rather than editing the old one. Old scoresheets remain as a record of the bar at that point in time.

--- a/rubrics/scoresheets/benchmark-agentdojo.md
+++ b/rubrics/scoresheets/benchmark-agentdojo.md
@@ -1,0 +1,29 @@
+---
+rubric: benchmark-quality-rubric.md
+artefact: AgentDojo
+artefact_url: https://github.com/ethz-spylab/agentdojo
+artefact_version: as published, NeurIPS 2024 D&B Track
+scored_by: maintainer (worked example)
+scored_on: 2026-05-01
+rater_count: 1
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Scope and relevance to agentic systems | 3 | The benchmark places agents in realistic environments (Slack, Banking, Travel, Workspace) and evaluates them on tasks that exercise tool use, indirect prompt injection through tool results, and multi-step planning. This maps directly to multiple chains in this field guide: [Prompt Injection → Tool Misuse](../../docs/agentic-attack-chains/prompt-injection-tool-misuse.md), [Hidden Instruction in Document Ingestion](../../docs/agentic-attack-chains/hidden-instruction-document-ingestion.md), and aspects of [Code-Execution Side Effects](../../docs/agentic-attack-chains/code-execution-side-effects.md). | Strong: covers multiple agentic surfaces with realistic adversarial scenarios. |
+| Methodological soundness | 3 | Published in the NeurIPS 2024 Datasets and Benchmarks Track, which subjects benchmarks to peer review for methodology, baselines, and threats-to-validity. Explicit threat model (attacker controls a subset of tool outputs); baselines for both attack success and task utility; ablations across model and defence configurations. | Strong: pre-published methodology with explicit threat model and ablations. |
+| Evidence requirements | 3 | The repository publishes per-task definitions, the full set of tools and environments, the attack injection points, and supports recording per-trial transcripts. Results are reproducible per-task, not only aggregate. | Strong. |
+| Transparency of limitations | 2 | The paper discusses limitations including the constructed-environment trade-off (realistic but not real), English-only prompts, the attack realism choices, and the fixed task set. | Adequate: limitations are stated and reasoned but not exhaustively quantified; the document does not work through specific scenarios where the benchmark's conclusions stop applying. |
+| Reproducibility | 3 | Pip-installable Python package with pinned dependencies; deterministic execution given a fixed seed and model; CI-runnable; public leaderboard tracks runs across model and defence configurations. | Strong. |
+
+## Aggregate
+
+- Raw total: **14 / 15**
+- Floor rule triggered: no
+- Verdict: **Recommended; cite confidently**
+
+## Reviewer commentary
+
+AgentDojo is a load-bearing benchmark for agentic prompt-injection and tool-use evaluation: it covers multiple chains from this repo's library, has been peer-reviewed at a venue that scrutinises methodology, and ships reproducible artefacts including a pip-installable runtime and per-task definitions. The single area for improvement is *Transparency of limitations* — the existing limitations discussion is honest but not exhaustively quantified, and a reader has to infer the boundary conditions from the construction of the environments rather than from an explicit scope-of-claims statement. This is a strong candidate for the first concrete entry in [docs/06-benchmarks.md](../../docs/06-benchmarks.md)'s currently empty catalogue.

--- a/rubrics/scoresheets/case-study-tool-misuse-credential-leak.md
+++ b/rubrics/scoresheets/case-study-tool-misuse-credential-leak.md
@@ -1,0 +1,28 @@
+---
+rubric: case-study-rubric.md
+artefact: Tool Misuse Exposes Cloud Credentials
+artefact_path: docs/09-incident-case-studies.md (section "Example Case Study: Tool Misuse Leading to Credential Leak")
+scored_by: maintainer (worked example)
+scored_on: 2026-05-01
+rater_count: 1
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Clarity of what happened and why it matters | 2 | *What happened* and *Why it matters* fields are filled with concise prose: *"An agentic AI system with tool access was prompted to retrieve sensitive data... used a file system tool to access a credentials file and then sent the contents to an external endpoint."* A reader can summarise the incident in two sentences after a single read. | Adequate but not strong: narrative is concise rather than richly sequenced; no named actors or temporal anchors. |
+| Attack surface and exploit path analysis | 2 | *Attack surface* names "File system tool, external API tool, agent prompt interface" — repo-native vocabulary from [docs/02-attack-surfaces.md](../../docs/02-attack-surfaces.md). *Exploit path* connects the surfaces: *"Malicious prompt → agent uses file system tool → reads credentials file → uses API tool to send data externally."* | Path is connected and surfaces are named. Could lift to 3 by explicitly naming the chain (this is *Prompt Injection → Tool Misuse* composed with *Credential Overreach* and *Code-Execution Side Effects*). |
+| Impact and controls discussion | 2 | *Impact* is concrete: *"Cloud account compromise, potential data breach, regulatory exposure."* *Controls* names patterns by file: *"Tool call restrictions, credential vaulting, output filtering, audit logging, approval gates for sensitive actions"* with a reference to [patterns/credential-and-token-boundaries.md](../../patterns/credential-and-token-boundaries.md) and [patterns/secure-tool-calling.md](../../patterns/secure-tool-calling.md). | Adequate: controls listed and tied to patterns. Could lift to 3 by walking through which control would have interrupted the chain at which step (e.g., *"a per-task allowlist on the file-system tool would have refused the credentials path; absent that, output-filtering on the external API call would have caught the secret in transit"*). |
+| Evidence and references | 2 | *Maturity level* and *Evidence level* are explicit: *"Plausible, based on real-world agent tool integrations"* and *"Hypothetical, but supported by public incident reports and research."* References point to internal patterns and the attack-surfaces doc. | Adequate. Could lift to 3 by citing one or two specific public incident reports or research papers that support the *"based on real-world agent tool integrations"* claim. |
+| Maturity and generalisability | 2 | The case generalises into a defensive lesson useful beyond its original setting: any agent with file-system access plus an external network tool faces this composition risk. Tied to two patterns and at least one chain. | Adequate. Could lift to 3 by being positioned explicitly as a teaching example (e.g., *"This case is suitable as the canonical illustration of credential overreach via tool composition; cited from [patterns/credential-and-token-boundaries.md](../../patterns/credential-and-token-boundaries.md)"*) and added to a red-team scenario library. |
+
+## Aggregate
+
+- Raw total: **10 / 15**
+- Floor rule triggered: no
+- Verdict: **Publish with reviewer-noted caveats**
+
+## Reviewer commentary
+
+The case study is consistently *adequate* across all five criteria — it follows the template, names surfaces and patterns from repo-native vocabulary, and reaches a defensive lesson that generalises beyond its setting. None of the criteria is genuinely weak, but none is strong either. The single highest-leverage improvement is on *Impact and controls discussion*: rewriting the controls list as a per-step walk-through (which control would have interrupted the chain at which step) would lift the case from "useful illustration" to "teaching example," and would naturally surface a citation point for the case from the relevant pattern files. The next-most-useful improvement is on *Evidence and references*, by citing one or two public incident reports that support the *"plausible based on real-world integrations"* maturity claim.

--- a/rubrics/scoresheets/resource-chain-prompt-injection-tool-misuse.md
+++ b/rubrics/scoresheets/resource-chain-prompt-injection-tool-misuse.md
@@ -1,0 +1,30 @@
+---
+rubric: resource-quality-rubric.md
+artefact: Prompt Injection to Tool Misuse (chain stub)
+artefact_url_or_path: docs/agentic-attack-chains/prompt-injection-tool-misuse.md
+artefact_version: HEAD on branch claude/optimistic-chandrasekhar-59a942 (post PR #2)
+last_checked: 2026-05-01
+scored_by: maintainer (worked example)
+scored_on: 2026-05-01
+rater_count: 1
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Relevance to agentic AI security | 3 | Page is the canonical entry for the *Prompt Injection → Tool Misuse* chain in the [chain library README](../../docs/agentic-attack-chains/README.md), one of the foundational chains in the field guide's progressive-breach model. | Central, not tangential; chain is named in [docs/01-threat-model.md](../../docs/01-threat-model.md) and [docs/03-agentic-attack-chains.md](../../docs/03-agentic-attack-chains.md). |
+| Evidence-based claims | 2 | The page's claims (untrusted input bypasses policy check; layered controls interrupt the chain) align with referenced architecture in [patterns/secure-tool-calling.md](../../patterns/secure-tool-calling.md). The [attack-chain-template](../../docs/agentic-attack-chains/attack-chain-template.md) fields *Detection signals*, *Test case*, and *Residual risk* are not yet filled in, so empirical claims that would normally live in those fields are absent. | Adequate, not strong: claims are well-aligned but not yet fully evidenced through the template structure. |
+| Clarity and editorial quality | 3 | Two well-chosen Mermaid diagrams (sequenceDiagram for the attack, block-beta for layered defence) with one-sentence captions describing the attack and defence themselves, not the diagrams. British English; calm, evidence-led tone. | Diagrams reuse repo-native vocabulary (*source labelling*, *instruction-data separation*, *policy decision*, *tool broker*, *outcome control*). |
+| Recency and ongoing relevance | 3 | Updated 2026-05-01 (this branch). Aligns with the current chain taxonomy. | Stub was created 2026-05-01 and updated the same day with diagrams. |
+| Transparency of limitations | 2 | The line *"See [attack-chain-template.md](../../docs/agentic-attack-chains/attack-chain-template.md) for full structure"* implicitly acknowledges that the full template fields are not yet filled in. | Adequate but could be lifted to 3 by adding an explicit *Status* line stating "stub; full template fields not yet completed." |
+
+## Aggregate
+
+- Raw total: **13 / 15**
+- Floor rule triggered: no
+- Verdict: **Include / cite from field guide**
+
+## Reviewer commentary
+
+Strongest dimension is clarity: the recently added attack and defence diagrams give the page genuine teaching value, and the captions describe the chain rather than the diagram literally. Weakest is evidence-based claims, because the attack-chain-template fields (detection signals, test case, residual risk) are not populated — the page is currently descriptive rather than fully analytic. The single most useful follow-up would be to fill in those template fields so the page can ground concrete detection and mitigation work, after which the score would lift to 14–15.

--- a/rubrics/scoresheets/resource-owasp-llm-top-10.md
+++ b/rubrics/scoresheets/resource-owasp-llm-top-10.md
@@ -1,0 +1,30 @@
+---
+rubric: resource-quality-rubric.md
+artefact: OWASP Top 10 for LLM Applications
+artefact_url_or_path: https://genai.owasp.org/llm-top-10/
+artefact_version: 2025 release
+last_checked: 2026-05-01
+scored_by: maintainer (worked example)
+scored_on: 2026-05-01
+rater_count: 1
+---
+
+## Scores
+
+| Criterion | Score (0–3) | Evidence | Notes |
+|---|---|---|---|
+| Relevance to agentic AI security | 2 | Several items map directly to agentic surfaces — *LLM01 Prompt Injection* covers the influence stage of the [Prompt Injection → Tool Misuse chain](../../docs/agentic-attack-chains/prompt-injection-tool-misuse.md); *LLM06 Excessive Agency* aligns with [Credential Overreach](../../docs/agentic-attack-chains/credential-overreach.md) and [Workflow Automation Abuse](../../docs/agentic-attack-chains/workflow-automation-abuse.md); *LLM02 Sensitive Information Disclosure* aligns with [Code-Execution Side Effects](../../docs/agentic-attack-chains/code-execution-side-effects.md). | Adequate: addresses agentic surfaces but is LLM-application-centric rather than agent-execution-centric. Multi-agent contamination, MCP capability governance, and memory-poisoning lifecycles are not first-class topics. |
+| Evidence-based claims | 2 | Authored by a community of named experts; each item lists prevention strategies with references to public incidents and research papers; load-bearing claims are sourced. | Adequate. Some prevention recommendations are descriptive of patterns rather than empirically validated; not all items distinguish empirical claim from informed opinion. |
+| Clarity and editorial quality | 3 | Each item follows the same structure (description → common examples → prevention). Definitions are precise; the document is widely used as a reference and is well-edited. | Sets the bar for accessible LLM-security reference material. |
+| Recency and ongoing relevance | 3 | 2025 release current within twelve months as of *last_checked*. OWASP maintains the list with versioned releases and a public revision history. | Strong. |
+| Transparency of limitations | 2 | Scope statement is explicit (LLM applications, not full agentic systems); each item acknowledges that the prevention list is non-exhaustive. | Adequate. Limitations are stated but not quantified or worked through with examples; the document does not enumerate what it explicitly does *not* claim to cover (e.g., multi-agent orchestration, MCP governance). |
+
+## Aggregate
+
+- Raw total: **12 / 15**
+- Floor rule triggered: no
+- Verdict: **Include / cite from field guide**
+
+## Reviewer commentary
+
+Strongest dimensions are clarity and recency: the document is a maintained, well-edited reference that contributors and reviewers can use as a shared vocabulary. Weakest dimensions are relevance and transparency, because the document is LLM-application-shaped rather than agent-execution-shaped — several agentic surfaces this field guide treats as first-class (multi-agent contamination, MCP capability governance, memory lifecycle) sit at the edges of OWASP's framing. Cite as a foundational standard and a shared vocabulary, but pair with chain-specific resources for the agentic-execution surfaces it does not cover in depth.


### PR DESCRIPTION
## Summary

- Upgrades the four `rubrics/` files from stubs to a usable v1 framework: per-criterion anchored descriptors, scoring procedure, aggregation rule, scoresheet template, inter-rater agreement placeholder. Original criteria preserved; rubric file changes are append-only.
- Adds `rubrics/README.md` opening with the four-way evaluation principle (rubrics vs tests vs assertions vs LLM-as-judge) and a *when to use each rubric* table.
- Adds `rubrics/scoresheets/` with one worked example per rubric and a directory README explaining the naming convention.
- Adds a single CI gate that requires a scoresheet when a PR adds a new tracked artefact.
- PR template gains one reminder line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)