### PR TITLE
Add Related Projects section to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ Substantial entries should explain:
 
 The repository favours fewer, better-labelled entries over a large unstructured catalogue.
 
+## Related Projects
+
+Companion field guides by the same maintainer covering adjacent areas of AI. Read alongside this repository for broader context on how agentic AI is being built and applied beyond the security boundary.
+
+| Repository | Focus |
+| --- | --- |
+| [Awesome Agentic Engineering](https://github.com/natnew/Awesome-Agentic-Engineering) | Engineering practices, patterns, and tooling for building agentic AI systems. |
+| [Awesome AI Scientists](https://github.com/natnew/awesome-ai-scientists) | AI for scientific research, discovery, and AI-as-scientist tooling. |
+| [Awesome Physical AI](https://github.com/natnew/awesome-physical-ai) | Physical AI: robotics, embodied agents, and sensor-driven systems. |
+
 ## Licence
 
 This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Adds a new **Related Projects** section to the main README, sitting just before the Licence section.
- Links the three companion field guides by the same maintainer: [Awesome Agentic Engineering](https://github.com/natnew/Awesome-Agentic-Engineering), [Awesome AI Scientists](https://github.com/natnew/awesome-ai-scientists), and [Awesome Physical AI](https://github.com/natnew/awesome-physical-ai).
- Each link has a one-line focus description; existing README content is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)