### PR TITLE
Add four secure-architecture diagrams

### DIFF
--- a/docs/04-defence-architecture.md
+++ b/docs/04-defence-architecture.md
@@ -127,6 +127,34 @@ Not every action needs the same control strength. The architecture should escala
 
 The important design choice is to evaluate risk from the relationship between intent, authority, data, tool, and outcome rather than from the model output alone.
 
+## Identity And Delegation
+
+Authority in an agentic system rarely flows in a straight line from the user. A user delegates a task scope to an agent; the agent narrows that scope into sub-tasks for sub-agents or tool calls; a credential broker issues short-lived authority bound to each step. At every hand-off, the *effective identity* and the *credential scope* should be narrower than what came before — never broader.
+
+The diagram below uses a sequence diagram because the model is fundamentally about identity flow over time and where scope narrowing happens between participants.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant Sub as Sub-agent
+  participant Br as Credential broker
+  participant T as Tool
+
+  U->>A: Delegated authority<br/>(approved task scope)
+  note right of A: Effective identity = User-on-behalf-of-Agent.<br/>Authority pinned to task scope.
+  A->>Sub: Sub-task with<br/>narrowed scope
+  note right of Sub: Effective identity = Agent-on-behalf-of-User.<br/>Sub-scope is subset of task scope.
+  Sub->>Br: Request credential<br/>for tool call
+  Br->>Br: Pre-issuance<br/>scope check
+  Br->>T: Credential bound<br/>to credential scope
+  T-->>Sub: Result within<br/>credential scope
+  Sub-->>A: Result within<br/>sub-scope
+  A-->>U: Outcome within<br/>task scope
+```
+
+Source: [identity-delegation-boundary.mmd](../visuals/identity-delegation-boundary.mmd). The diagram makes three things explicit: effective identity changes at every hand-off and is recorded, the credential broker is the enforcement point where scope narrowing actually happens, and the outcome that returns to the user must remain within the original task scope.
+
 ## Human Approval Gates
 
 Human approval is a control only when the reviewer can see the evidence needed to make a decision. A button after a confident summary is not enough.
@@ -141,6 +169,24 @@ Approval prompts should show:
 6. The expected effect, rollback path, and business owner where relevant.
 
 Approval should be required for actions that are sensitive, irreversible, outside normal scope, ambiguous, high-impact, or dependent on weak evidence.
+
+The lifecycle of an approval request moves through six explicit states. A state diagram is used because each state has named entry and exit conditions that the runtime should be able to log, replay, and audit independently.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Requested : Agent proposes<br/>sensitive action
+  Requested --> EvidenceAssembled : Source context, risk summary,<br/>parameters, identity, expected effect attached
+  EvidenceAssembled --> UnderReview : Approval prompt<br/>shown to reviewer
+  UnderReview --> Approved : Reviewer signs off<br/>(approver identity + timestamp)
+  UnderReview --> Denied : Reviewer rejects<br/>with reason
+  UnderReview --> Revised : Reviewer requests<br/>changes
+  Revised --> Requested : Agent re-proposes<br/>within scope
+  Approved --> Logged : Approval record<br/>linked to trace
+  Denied --> Logged : Decision record<br/>linked to trace
+  Logged --> [*]
+```
+
+Source: [approval-gate.mmd](../visuals/approval-gate.mmd). The diagram makes the difference between *Approved* and *Logged* explicit: an approval is not complete until the approval record (with evidence shown, approver identity, decision, and timestamp) is linked to the task trace.
 
 ## Outcome Control
 
@@ -157,6 +203,53 @@ Outcome controls can include:
 5. Alerts when the observed result differs from the expected result.
 
 This is where the architecture connects access control with organisational impact.
+
+## Observability And Audit Trail
+
+The audit layer is what makes an agentic system reconstructable. A single *trace identifier* should bind the full set of stage records produced during a task — prompt, context, decision, credential, approval, tool call, memory, output, and downstream effect — so a reviewer can follow the chain from influence to outcome without stitching logs across systems.
+
+The diagram below uses an entity-relationship view because the model is fundamentally about *which records share a trace* and which fields each record must carry.
+
+```mermaid
+erDiagram
+  TRACE ||--|| PROMPT_RECORD : binds
+  TRACE ||--|| CONTEXT_RECORD : binds
+  TRACE ||--|{ DECISION_RECORD : binds
+  TRACE ||--|{ CREDENTIAL_RECORD : binds
+  TRACE ||--o{ APPROVAL_RECORD : binds
+  TRACE ||--|{ TOOL_CALL_RECORD : binds
+  TRACE ||--o{ MEMORY_RECORD : binds
+  TRACE ||--|| OUTPUT_RECORD : binds
+  TRACE ||--o{ DOWNSTREAM_RECORD : binds
+
+  TRACE {
+    string trace_identifier
+    string task_scope
+    string effective_identity
+    timestamp created
+  }
+  DECISION_RECORD {
+    string matched_rule
+    string risk_factors
+    string decision
+    string reason
+  }
+  APPROVAL_RECORD {
+    string evidence_shown
+    string approver_identity
+    string decision
+    timestamp approved_at
+  }
+  TOOL_CALL_RECORD {
+    string tool_schema
+    string parameters
+    string broker_decision
+    string credential_scope
+    string outcome
+  }
+```
+
+Source: [observability-audit-trail.mmd](../visuals/observability-audit-trail.mmd). Approval and downstream records are optional (`o{`) because not every task needs an approval or has a downstream side effect; everything else is required so that a reviewer can always reconstruct the action path.
 
 ## Architecture Review Questions
 

--- a/patterns/secure-agent-runtime.md
+++ b/patterns/secure-agent-runtime.md
@@ -76,6 +76,35 @@ Source: [secure-agent-runtime-boundaries.mmd](../visuals/secure-agent-runtime-bo
 
 For the broader system-level reference model, see [visuals/secure-agent-reference-architecture.mmd](../visuals/secure-agent-reference-architecture.mmd).
 
+## Sandboxed Execution Lifecycle
+
+The boundary diagram above shows when controls fire. The state diagram below shows the lifecycle of a single piece of generated code or command as it crosses three execution phases: pre-execution checks, sandboxed bounded run, and post-execution disposition. A state diagram with composite states is used because the phases are nested — each phase has its own internal transitions — and because every terminal state (committed, rolled back, quarantined, denied) must be loggable on its own.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PreExecution
+  state PreExecution {
+    [*] --> Generated : Code or<br/>command produced
+    Generated --> DryRun : Run in<br/>sandbox preview
+    DryRun --> ImpactAssessed : Dry-run output<br/>evaluated by policy
+  }
+  PreExecution --> SandboxedExecution : Approved within<br/>blast radius
+  PreExecution --> Denied : Outside approved scope
+  state SandboxedExecution {
+    [*] --> BoundedRun : Within blast radius<br/>and rate limits
+    BoundedRun --> Validated : Post-action validation
+  }
+  SandboxedExecution --> Committed : Result within bounds
+  SandboxedExecution --> RolledBack : Result outside bounds
+  SandboxedExecution --> Quarantined : Sandbox flag<br/>mid-run
+  Committed --> [*]
+  RolledBack --> [*]
+  Quarantined --> [*]
+  Denied --> [*]
+```
+
+Source: [sandboxed-code-execution.mmd](../visuals/sandboxed-code-execution.mmd). The diagram makes the outcome-control vocabulary explicit: dry runs and impact assessment happen before any real effect, blast-radius and rate-limit bounds wrap the run itself, and the post-execution state — committed, rolled back, quarantined, or denied — is always one of four logged outcomes, never an implicit success.
+
 ## Implementation Notes
 
 These notes are vendor-agnostic. They describe the shape of the controls, not a specific framework.

--- a/visuals/README.md
+++ b/visuals/README.md
@@ -32,6 +32,9 @@ The full selection rule set is documented at the top of the diagram review notes
 - [Agent, Tool, And Memory Attack Flow](agent-tool-memory-attack-flow.mmd) — `sequenceDiagram`. Step-by-step interactions between user, agent, policy, tool broker, tool, memory, and audit.
 - [AI Defense Plane](ai-defense-plane.mmd) — `block-beta`. Discover, Protect, and Govern as three stacked layers wrapping the agentic execution system.
 - [Secure Agent Reference Architecture](secure-agent-reference-architecture.mmd) — `block-beta`. Seven stacked components of the layered control model.
+- [Identity And Delegation Boundary](identity-delegation-boundary.mmd) — `sequenceDiagram`. Identity flow from user to agent to sub-agent to credential broker to tool, with scope narrowing at every hand-off.
+- [Approval Gate](approval-gate.mmd) — `stateDiagram-v2`. Lifecycle of an approval request from Requested through EvidenceAssembled, UnderReview, and a logged terminal decision.
+- [Observability And Audit Trail](observability-audit-trail.mmd) — `erDiagram`. Trace identifier bound to prompt, context, decision, credential, approval, tool-call, memory, output, and downstream records.
 
 ### Pattern diagrams
 
@@ -42,6 +45,7 @@ The full selection rule set is documented at the top of the diagram review notes
 - [Secure MCP Boundaries](secure-mcp-boundaries.mmd) — `block-beta`. Three layers: agent host, trust boundary, MCP servers.
 - [Memory Security Flow](memory-security-flow.mmd) — `stateDiagram-v2`. Lifecycle of a memory entry from proposed to expired, blocked, or quarantined.
 - [Credential And Token Boundaries](credential-token-boundaries.mmd) — `stateDiagram-v2`. Lifecycle of a credential from requested to expired, revoked, or denied.
+- [Sandboxed Code Execution](sandboxed-code-execution.mmd) — `stateDiagram-v2` with composite states. Lifecycle of generated code or commands across pre-execution checks, sandboxed bounded run, and post-execution disposition (committed, rolled back, quarantined, or denied).
 
 ### Navigation, lifecycle, and library-index diagrams
 
@@ -49,13 +53,6 @@ The full selection rule set is documented at the top of the diagram review notes
 - [Chain Library Index](chain-library-index.mmd) — `mindmap`. The ten attack-chain stubs grouped by progressive-breach-model stage.
 - [Case-Study Lifecycle](case-study-lifecycle.mmd) — `stateDiagram-v2`. Lifecycle of an incident case study from detected to closed.
 - [Open-Research Framing](open-research-framing.mmd) — `stateDiagram-v2`. Lifecycle of a research question from failure mode to revision.
-
-## Planned Coverage
-
-Future visuals will cover:
-
-- Sandboxing and code execution boundaries.
-- Multi-agent communication and delegated authority boundaries.
 
 ## Diagram Standard
 

--- a/visuals/approval-gate.mmd
+++ b/visuals/approval-gate.mmd
@@ -1,0 +1,11 @@
+stateDiagram-v2
+  [*] --> Requested : Agent proposes<br/>sensitive action
+  Requested --> EvidenceAssembled : Source context, risk summary,<br/>parameters, identity, expected effect attached
+  EvidenceAssembled --> UnderReview : Approval prompt<br/>shown to reviewer
+  UnderReview --> Approved : Reviewer signs off<br/>(approver identity + timestamp)
+  UnderReview --> Denied : Reviewer rejects<br/>with reason
+  UnderReview --> Revised : Reviewer requests<br/>changes
+  Revised --> Requested : Agent re-proposes<br/>within scope
+  Approved --> Logged : Approval record<br/>linked to trace
+  Denied --> Logged : Decision record<br/>linked to trace
+  Logged --> [*]

--- a/visuals/identity-delegation-boundary.mmd
+++ b/visuals/identity-delegation-boundary.mmd
@@ -1,0 +1,17 @@
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant Sub as Sub-agent
+  participant Br as Credential broker
+  participant T as Tool
+
+  U->>A: Delegated authority<br/>(approved task scope)
+  note right of A: Effective identity = User-on-behalf-of-Agent.<br/>Authority pinned to task scope.
+  A->>Sub: Sub-task with<br/>narrowed scope
+  note right of Sub: Effective identity = Agent-on-behalf-of-User.<br/>Sub-scope is subset of task scope.
+  Sub->>Br: Request credential<br/>for tool call
+  Br->>Br: Pre-issuance<br/>scope check
+  Br->>T: Credential bound<br/>to credential scope
+  T-->>Sub: Result within<br/>credential scope
+  Sub-->>A: Result within<br/>sub-scope
+  A-->>U: Outcome within<br/>task scope

--- a/visuals/observability-audit-trail.mmd
+++ b/visuals/observability-audit-trail.mmd
@@ -1,0 +1,36 @@
+erDiagram
+  TRACE ||--|| PROMPT_RECORD : binds
+  TRACE ||--|| CONTEXT_RECORD : binds
+  TRACE ||--|{ DECISION_RECORD : binds
+  TRACE ||--|{ CREDENTIAL_RECORD : binds
+  TRACE ||--o{ APPROVAL_RECORD : binds
+  TRACE ||--|{ TOOL_CALL_RECORD : binds
+  TRACE ||--o{ MEMORY_RECORD : binds
+  TRACE ||--|| OUTPUT_RECORD : binds
+  TRACE ||--o{ DOWNSTREAM_RECORD : binds
+
+  TRACE {
+    string trace_identifier
+    string task_scope
+    string effective_identity
+    timestamp created
+  }
+  DECISION_RECORD {
+    string matched_rule
+    string risk_factors
+    string decision
+    string reason
+  }
+  APPROVAL_RECORD {
+    string evidence_shown
+    string approver_identity
+    string decision
+    timestamp approved_at
+  }
+  TOOL_CALL_RECORD {
+    string tool_schema
+    string parameters
+    string broker_decision
+    string credential_scope
+    string outcome
+  }

--- a/visuals/sandboxed-code-execution.mmd
+++ b/visuals/sandboxed-code-execution.mmd
@@ -1,0 +1,20 @@
+stateDiagram-v2
+  [*] --> PreExecution
+  state PreExecution {
+    [*] --> Generated : Code or<br/>command produced
+    Generated --> DryRun : Run in<br/>sandbox preview
+    DryRun --> ImpactAssessed : Dry-run output<br/>evaluated by policy
+  }
+  PreExecution --> SandboxedExecution : Approved within<br/>blast radius
+  PreExecution --> Denied : Outside approved scope
+  state SandboxedExecution {
+    [*] --> BoundedRun : Within blast radius<br/>and rate limits
+    BoundedRun --> Validated : Post-action validation
+  }
+  SandboxedExecution --> Committed : Result within bounds
+  SandboxedExecution --> RolledBack : Result outside bounds
+  SandboxedExecution --> Quarantined : Sandbox flag<br/>mid-run
+  Committed --> [*]
+  RolledBack --> [*]
+  Quarantined --> [*]
+  Denied --> [*]


### PR DESCRIPTION
## Summary

- Adds four standalone Mermaid diagrams covering gaps identified in the visuals audit: approval-gate lifecycle, observability and audit trail (trace-record entity model), sandboxed code execution lifecycle, and agent identity and delegation boundary.
- Each diagram is embedded in the most relevant doc with a one-sentence caption and a `Source:` attribution line, matching the existing embedding convention.
- Two diagrams are embedded under new sections in `docs/04-defence-architecture.md` (Identity And Delegation, Observability And Audit Trail); one in the existing Human Approval Gates section there; one in `patterns/secure-agent-runtime.md` under a new Sandboxed Execution Lifecycle section.
- `visuals/README.md` is updated: the four new entries are listed under Available Now, and the now-fulfilled Planned Coverage section is removed.
- Node labels reuse repo-native vocabulary (effective identity, delegated authority, task scope, end-to-end trace, blast radius, dry run, quarantine, outcome control); no existing diagrams or doc sections are modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)