### PR TITLE
Fix YAML frontmatter and Mermaid rendering on GitHub

### DIFF
--- a/docs/03-agentic-attack-chains.md
+++ b/docs/03-agentic-attack-chains.md
@@ -21,7 +21,7 @@ Untrusted language or data
 -> organisational impact
 ```
 
-The breach progression is shown below as a timeline because the model is fundamentally chronological — each stage marks a step further along the path from untrusted input to organisational impact.
+The breach progression below shows eight chronological stages from untrusted input to organisational impact.
 
 ```mermaid
 timeline

--- a/patterns/README.md
+++ b/patterns/README.md
@@ -23,7 +23,7 @@ mindmap
       Limitations
 ```
 
-Source: [pattern-shape.mmd](../visuals/pattern-shape.mmd). A mindmap is used because the pattern shape is a conceptual taxonomy of sections, not a process — readers should see the standard structure at a glance.
+Source: [pattern-shape.mmd](../visuals/pattern-shape.mmd).
 
 ## Planned Coverage
 

--- a/patterns/secure-mcp.md
+++ b/patterns/secure-mcp.md
@@ -53,7 +53,7 @@ columns 1
   Audit["Observability and audit"]
 ```
 
-Source: [secure-mcp-boundaries.mmd](../visuals/secure-mcp-boundaries.mmd). A block diagram is used because the point is the trust boundary between three layers (host, boundary, servers), not the temporal flow. The picture clarifies that capabilities are not transparent extensions of the host: there is a layer of checks between them.
+Source: [secure-mcp-boundaries.mmd](../visuals/secure-mcp-boundaries.mmd). The picture clarifies that capabilities are not transparent extensions of the host: there is a layer of checks between them.
 
 ## Implementation Notes
 

--- a/patterns/secure-tool-calling.md
+++ b/patterns/secure-tool-calling.md
@@ -69,7 +69,7 @@ sequenceDiagram
   T->>L: Trace
 ```
 
-Source: [secure-tool-calling-flow.mmd](../visuals/secure-tool-calling-flow.mmd). A sequence diagram is used because tool calling is a step-by-step exchange between named participants (agent, broker, policy, credential broker, tool runtime, audit). The diagram is the canonical picture of "the agent never reaches the tool runtime directly".
+Source: [secure-tool-calling-flow.mmd](../visuals/secure-tool-calling-flow.mmd). The diagram is the canonical picture of "the agent never reaches the tool runtime directly".
 
 ## Implementation Notes
 

--- a/rubrics/scoresheets/case-study-tool-misuse-credential-leak.md
+++ b/rubrics/scoresheets/case-study-tool-misuse-credential-leak.md
@@ -1,7 +1,7 @@
 ---
 rubric: case-study-rubric.md
 artefact: Tool Misuse Exposes Cloud Credentials
-artefact_path: docs/09-incident-case-studies.md (section "Example Case Study: Tool Misuse Leading to Credential Leak")
+artefact_path: 'docs/09-incident-case-studies.md (Example Case Study — Tool Misuse Leading to Credential Leak)'
 scored_by: maintainer (worked example)
 scored_on: 2026-05-01
 rater_count: 1

--- a/visuals/README.md
+++ b/visuals/README.md
@@ -64,7 +64,7 @@ Every diagram should:
 - Use short, concise labels.
 - Avoid unexplained acronyms.
 - Render correctly in GitHub Markdown and MkDocs Material.
-- Have a short caption above the embedded block explaining what it shows and why this syntax was chosen.
+- Have a short caption above the embedded block explaining what it shows.
 
 ## Use In The Field Guide
 

--- a/visuals/ai-defense-plane.mmd
+++ b/visuals/ai-defense-plane.mmd
@@ -1,7 +1,9 @@
 block-beta
 columns 3
-  Discover["Discover\nInventory and ownership"]
-  Protect["Protect\nRuntime decisions and controls"]
-  Govern["Govern\nAuthority, evidence, accountability"]
-  System["Agentic execution system: agents, context, tools, memory, authority, downstream"]:3
-  Evidence["Audit and assurance evidence"]:3
+  Discover["Discover<br/>Inventory and<br/>ownership"]
+  Protect["Protect<br/>Runtime decisions<br/>and controls"]
+  Govern["Govern<br/>Authority, evidence<br/>and accountability"]
+
+  System["Agentic execution system<br/>agents · context · tools · memory<br/>authority · downstream"]:3
+
+  Evidence["Audit and assurance<br/>evidence"]:3


### PR DESCRIPTION
## Summary

- `rubrics/scoresheets/case-study-tool-misuse-credential-leak.md` — `artefact_path` value is now quoted; the inner colon is replaced with an em-dash so GitHub's strict YAML parser stops failing the page.
- `visuals/ai-defense-plane.mmd` — replaces `\n` with `<br/>` in block-beta labels (the literal `\n` is interpreted by some Mermaid versions but not by GitHub's), and splits the long *System* label so it no longer overflows the block.
- `patterns/README.md`, `patterns/secure-tool-calling.md`, `patterns/secure-mcp.md`, `docs/03-agentic-attack-chains.md`, `visuals/README.md` — drops the diagram-type-justification sentences that explained why a particular Mermaid syntax was chosen; these were author-time scaffolding rather than reader value.

No new content; the changes are scoped to robustness on GitHub-rendered pages and to editorial trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)