### PR TITLE
Fix base-prefix on internal links and expand site content

### DIFF
--- a/docs/00-landscape-map.md
+++ b/docs/00-landscape-map.md
@@ -71,13 +71,13 @@ These surfaces overlap. A retrieved document can influence a tool call. A tool r
 
 Most agentic failures are not single events. They are paths across the execution system.
 
-```text
-Untrusted instruction
--> compromised intent
--> risky tool selection
--> delegated authority use
--> persistent state or downstream change
--> broader organisational impact
+```mermaid
+flowchart TD
+  A["Untrusted instruction"] --> B["Compromised intent"]
+  B --> C["Risky tool selection"]
+  C --> D["Delegated authority use"]
+  D --> E["Persistent state or downstream change"]
+  E --> F["Broader organisational impact"]
 ```
 
 Different systems will expose different paths, but the pattern is consistent: a weak boundary in one place becomes more serious when it is connected to tools, credentials, memory, automation, or other agents.

--- a/docs/01-threat-model.md
+++ b/docs/01-threat-model.md
@@ -6,30 +6,16 @@ It is a defensive taxonomy, not an exploit guide. The goal is to help teams ask 
 
 For the broader system map, start with the [landscape map](00-landscape-map.md).
 
-The mindmap below groups the ten failure modes into six families. 
+The table below groups the ten failure modes into six families.
 
-```mermaid
-mindmap
-  root((Failure modes))
-    Influence
-      Prompt injection
-      Goal hijacking
-      Context poisoning
-    Authority
-      Tool misuse
-      Credential misuse
-    State
-      Memory poisoning
-    Capability
-      MCP and extension compromise
-    Propagation
-      Multi-agent propagation
-    Outcome
-      Unsafe autonomous action
-      Monitoring blind spots
-```
-
-Source: [failure-mode-taxonomy.mmd](../visuals/failure-mode-taxonomy.mmd).
+| Family | Failure modes |
+| --- | --- |
+| Influence | Prompt injection; Goal hijacking; Context poisoning |
+| Authority | Tool misuse; Credential misuse |
+| State | Memory poisoning |
+| Capability | MCP and extension compromise |
+| Propagation | Multi-agent propagation |
+| Outcome | Unsafe autonomous action; Monitoring blind spots |
 
 ## Scope And Assumptions
 

--- a/docs/06-benchmarks.md
+++ b/docs/06-benchmarks.md
@@ -2,8 +2,68 @@
 
 This document catalogues and describes benchmarks for agentic AI security, including their scope, methodology, and limitations.
 
-## Contents
-- What makes a good benchmark for agentic systems
-- Catalogue of current benchmarks
-- Methodology and evaluation criteria
-- Known limitations and gaps
+## Why Benchmarks Matter And How To Read Them
+
+Benchmarks can provide useful evidence, but they are not proof that a production agent is secure. They should be paired with threat modelling, architecture review, runtime telemetry, and system-specific red teaming.
+
+Benchmark results are most useful when readers understand the boundary being tested: a model response, a threat snapshot, a simulated tool workflow, a red team scenario, or a production-like control path. Results should not be generalised beyond the tested environment without additional evidence.
+
+When you read a benchmark report, ask:
+
+- What is being scored — the model in isolation, an agent loop, or an end-to-end deployed system?
+- What threat model and trust boundary does the benchmark assume?
+- Which surfaces does it exercise (instructions, retrieved context, tools, credentials, memory, approvals, downstream actions)?
+- What does a passing or failing score actually demonstrate about real risk?
+
+## What Makes A Good Benchmark For Agentic Systems
+
+A useful agentic security benchmark generally:
+
+- Tests an agent in motion (tools, memory, state, multi-step reasoning), not only the underlying model.
+- States its threat model and trust boundary explicitly so readers can map the result to their own deployment.
+- Exercises adversarial inputs across more than one surface — for example, indirect prompt injection that lands in a tool call, or a poisoned retrieval that drives a memory write.
+- Reports both task success and security objectives, so improvements on one are not masked by regressions on the other.
+- Documents method, scoring, and limitations clearly enough for another team to reproduce or contest the result.
+- Provides reusable scenarios, payloads, or harnesses that teams can extend with their own tools, data, and policies.
+
+For the full criteria and scoring guide, see the [benchmark quality rubric](../rubrics/benchmark-quality-rubric.md).
+
+## Catalogue Of Current Benchmarks
+
+The table below summarises the public benchmarks and evaluation harnesses tracked by this repository. For full metadata (producer, source, coverage, last checked, limitations) see the [resource catalogue](../resources/benchmarks.md).
+
+| Benchmark | Producer | What it tests | Maturity |
+| --- | --- | --- | --- |
+| [AgentDojo](https://github.com/ethz-spylab/agentdojo) | ETH Zurich SPY Lab | Tool-using agents under indirect prompt injection; defences vs. task completion | Emerging |
+| [Backbone Breaker Benchmark](https://www.lakera.ai/blog/the-backbone-breaker-benchmark) | Lakera (with UK AISI) | Backbone LLM behaviour at vulnerable agent moments via threat snapshots | Emerging, high-signal |
+| [Gandalf Agent Breaker](https://gandalf.lakera.ai/agent-breaker) | Lakera | Public testbed: RAG, browsing, tools, memory, prompt extraction, exfiltration | Medium |
+| [NVIDIA NeMo Agent Toolkit Red Teaming](https://github.com/NVIDIA/NeMo-Agent-Toolkit/tree/develop/examples/safety_and_security/retail_agent) | NVIDIA | End-to-end agent workflow evaluation with adversarial scenarios and risk scores | Practical example |
+| [CyberSecEval](https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks) | Meta Purple Llama | Cybersecurity knowledge, secure coding, abuse, prompt-injection-related tasks | Mature (model-level) |
+| [OWASP GenAI Red Teaming Guide](https://genai.owasp.org/resource/genai-red-teaming-guide/) | OWASP GenAI Security Project | Methodology for model, implementation, infrastructure, and runtime testing | Mature (guide) |
+| [Q4 2025 AI Agent Security Trends Report](https://www.lakera.ai/ai-security-guides/q4-2025-ai-agent-security-trends) | Lakera | Vendor-observed production attack traffic against early agentic systems | Medium (vendor report) |
+
+For richer notes on each entry — coverage, evidence quality, and caveats — see the full [benchmark catalogue](../resources/benchmarks.md).
+
+## Methodology And Evaluation Criteria
+
+Treat benchmark scores as one signal in a wider evaluation programme. The following references describe how to design, score, and combine evaluations:
+
+- [Red teaming and evaluation](05-red-teaming-and-evaluation.md) — methodology for scenario design, evidence requirements, and reporting.
+- [Benchmark quality rubric](../rubrics/benchmark-quality-rubric.md) — criteria for judging whether a benchmark is informative for a given system.
+- [Agent security readiness rubric](../rubrics/agent-security-readiness-rubric.md) — control coverage expectations a benchmark alone cannot demonstrate.
+
+## Known Limitations And Gaps
+
+Even strong benchmarks have meaningful gaps when applied to real agentic deployments:
+
+- Many benchmarks score the backbone LLM rather than the full deployed agent, so they miss tool brokering, credential boundaries, memory controls, approvals, and downstream actions.
+- Coverage of memory poisoning, multi-agent propagation, and long-horizon autonomy is uneven across the public landscape.
+- Scenarios are often simplified, vendor-operated, or narrowly scoped; results rarely transfer between deployments without re-testing on the target system.
+- Defence comparisons can be misleading when the benchmark does not separate task success from security objectives.
+- Public benchmarks cannot cover production-specific tools, data, policies, and approval flows; system-specific tests are still required.
+
+## Where To Go Next
+
+- [Red teaming and evaluation](05-red-teaming-and-evaluation.md) for evaluation methodology.
+- [Rubrics](../rubrics/) for scoring guides used across this repository.
+- [Resources: benchmarks catalogue](../resources/benchmarks.md) for the full per-entry metadata.

--- a/site/scripts/check-links.mjs
+++ b/site/scripts/check-links.mjs
@@ -36,9 +36,13 @@ function resolveTarget(fromHtml, href) {
   if (!pathPart) return null; // pure fragment, same-page anchor
   let target;
   if (pathPart.startsWith('/')) {
-    // Site-absolute. Strip configured base if present.
-    let p = pathPart;
-    if (p.startsWith(SITE_BASE)) p = p.slice(SITE_BASE.length) || '/';
+    // Site-absolute. Internal links MUST include the configured base, otherwise
+    // they 404 once the site is served from /<repo>/. Treat missing-base paths
+    // as broken rather than silently resolving them under dist/.
+    if (!pathPart.startsWith(SITE_BASE + '/') && pathPart !== SITE_BASE) {
+      return join(distDir, '__missing-base__', pathPart);
+    }
+    const p = pathPart.slice(SITE_BASE.length) || '/';
     target = join(distDir, p);
   } else {
     target = resolve(dirname(fromHtml), pathPart);

--- a/site/scripts/sync-content.mjs
+++ b/site/scripts/sync-content.mjs
@@ -14,6 +14,12 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..');
 const contentRoot = resolve(here, '..', 'src', 'content', 'docs');
 
+// Site base path — must match `base` in astro.config.mjs.
+// Internal markdown links rewritten by this script need this prefix so they
+// resolve correctly under GitHub Pages (which serves the site at /<repo>/).
+const SITE_BASE = '/Awesome-Agentic-AI-Security';
+const withBase = (p) => `${SITE_BASE}${p}`;
+
 // [sourceRelPath, destRoute, slug]
 const filenameSlug = (file) => basename(file, extname(file)).replace(/^\d+-/, '').toLowerCase();
 
@@ -114,16 +120,16 @@ const BASENAME_ROUTES = {
 function rewriteLinks(md) {
   // 1. Rewrite resources/<slug>.md (handle ambiguity: resources/benchmarks vs evaluation/benchmarks).
   let out = md.replace(/\]\(([^)]*?)resources\/([\w-]+)\.md(#[^)]*)?\)/g,
-    (_m, _pre, slug, hash = '') => `](/resources/${slug}/${hash})`);
+    (_m, _pre, slug, hash = '') => `](${withBase(`/resources/${slug}/`)}${hash})`);
   // 2. Rewrite chains/<slug>.md
   out = out.replace(/\]\(([^)]*?)agentic-attack-chains\/([\w-]+)\.md(#[^)]*)?\)/g,
-    (_m, _pre, slug, hash = '') => `](/chains/${slug}/${hash})`);
+    (_m, _pre, slug, hash = '') => `](${withBase(`/chains/${slug}/`)}${hash})`);
   // 3. Generic: any .md link → look up by basename (strip leading digits).
   out = out.replace(/\]\(([^)\s]+\.md)(#[^)]*)?\)/g, (m, path, hash = '') => {
     const file = path.split('/').pop() || '';
     const base = file.replace(/\.md$/i, '').replace(/^\d+-/, '').toLowerCase();
     const route = BASENAME_ROUTES[base];
-    if (route) return `](${route}${hash})`;
+    if (route) return `](${withBase(route)}${hash})`;
     return m; // leave unknown .md links alone (will be flagged by checker)
   });
   // 4. Drop links to /visuals/*.mmd (the .mmd source files don't ship to the site)
@@ -135,11 +141,11 @@ function rewriteLinks(md) {
   const GH = 'https://github.com/natnew/Awesome-Agentic-AI-Security/tree/main';
   const GH_BLOB = 'https://github.com/natnew/Awesome-Agentic-AI-Security/blob/main';
   const dirMap = [
-    [/\]\((?:\.\.\/)*patterns\/\)/g, `](/defense/)`],
-    [/\]\((?:\.\.\/)*docs\/agentic-attack-chains\/\)/g, `](/guide/agentic-attack-chains/)`],
-    [/\]\((?:\.\.\/)*docs\/\)/g, `](/guide/)`],
-    [/\]\((?:\.\.\/)*resources\/\)/g, `](/resources/)`],
-    [/\]\((?:\.\.\/)*rubrics\/\)/g, `](/evaluation/rubrics/)`],
+    [/\]\((?:\.\.\/)*patterns\/\)/g, `](${withBase('/defense/')})`],
+    [/\]\((?:\.\.\/)*docs\/agentic-attack-chains\/\)/g, `](${withBase('/guide/agentic-attack-chains/')})`],
+    [/\]\((?:\.\.\/)*docs\/\)/g, `](${withBase('/guide/')})`],
+    [/\]\((?:\.\.\/)*resources\/\)/g, `](${withBase('/resources/')})`],
+    [/\]\((?:\.\.\/)*rubrics\/\)/g, `](${withBase('/evaluation/rubrics/')})`],
     [/\]\((?:\.\.\/)*visuals\/\)/g, `](${GH}/visuals)`],
     [/\]\((?:\.\.\/)*scoresheets\/(?:README\.md)?\)/g, `](${GH}/rubrics/scoresheets)`],
     [/\]\((?:\.\.\/)*CONTRIBUTING\.md\)/g, `](${GH_BLOB}/CONTRIBUTING.md)`],

--- a/site/src/pages/chains/index.astro
+++ b/site/src/pages/chains/index.astro
@@ -9,9 +9,24 @@ const url = (p: string) => `${base.replace(/\/$/, '')}/${p.replace(/^\//, '')}`;
   <div class="aas-page">
     <SectionBand variant="hero" eyebrow="ATTACK CHAINS" heading="Walk a breach chain end to end." lede="Each chain shows the local checks that pass at each step and the composed outcome that exceeds approved scope." >
       <div class="aas-grid aas-grid--3" style="margin-top:2rem">
-        <FeatureCard tag="LIBRARY" title="Chain library index" body="Browse all chains by surface, tactic, and impact." href={url('chains/')} />
+        <FeatureCard tag="LIBRARY" title="Chain library index" body="Browse all chains by surface, tactic, and impact." href={url('chains/#library')} />
         <FeatureCard tag="ENTRY" title="Agentic attack chains" body="The umbrella catalogue of multi-step agentic compromise paths." href={url('guide/agentic-attack-chains/')} />
         <FeatureCard tag="SURFACES" title="Attack surfaces" body="Map the surfaces a chain has to traverse before it lands." href={url('guide/attack-surfaces/')} />
+      </div>
+    </SectionBand>
+    <SectionBand eyebrow="LIBRARY" heading="Chain library.">
+      <div id="library" class="aas-grid aas-grid--3" style="margin-top:1rem">
+        <FeatureCard tag="INFLUENCE" title="Prompt injection to tool misuse" body="Hidden directives in user input become attacker-chosen tool parameters before any policy check fires." href={url('chains/prompt-injection-tool-misuse/')} />
+        <FeatureCard tag="INFLUENCE" title="Poisoned retrieved context" body="A planted document is ranked highly and treated as authoritative evidence for a high-impact decision." href={url('chains/poisoned-retrieved-context/')} />
+        <FeatureCard tag="INFLUENCE" title="Hidden instruction in document ingestion" body="Concealed directives inside ingested documents override policy and invoke tools the user never asked for." href={url('chains/hidden-instruction-document-ingestion/')} />
+        <FeatureCard tag="ACTION" title="Code-execution side effects" body="Visible output looks fine while filesystem writes, network calls, and leaked secrets quietly accumulate." href={url('chains/code-execution-side-effects/')} />
+        <FeatureCard tag="AUTHORITY" title="Credential overreach" body="An over-broad token is reused to invoke an unrelated tool, expanding impact beyond the user's intent." href={url('chains/credential-overreach/')} />
+        <FeatureCard tag="STATE" title="Memory poisoning" body="A poisoned fact written in one session is later retrieved as trusted state and shapes a future decision." href={url('chains/memory-poisoning/')} />
+        <FeatureCard tag="CAPABILITY" title="Unsafe MCP / tool extension" body="A capability added without registry review or scope check opens a path to high-impact downstream actions." href={url('chains/unsafe-mcp-tool-extension/')} />
+        <FeatureCard tag="PROPAGATION" title="Agent-to-agent contamination" body="One agent's manipulated output flows through orchestration into another agent that treats it as trusted input." href={url('chains/agent-to-agent-contamination/')} />
+        <FeatureCard tag="GOVERNANCE" title="Fake approval loop" body="A polished summary hides the real tool parameters and diff, so the human approves a sentence, not the action." href={url('chains/fake-approval-loop/')} />
+        <FeatureCard tag="GOVERNANCE" title="Workflow automation abuse" body="Many in-policy steps compose into broad effective authority and an irreversible action no single step would allow." href={url('chains/workflow-automation-abuse/')} />
+        <FeatureCard tag="TEMPLATE" title="Attack chain template" body="The standard template every chain in this library is built from." href={url('chains/attack-chain-template/')} />
       </div>
     </SectionBand>
   </div>


### PR DESCRIPTION
## Summary

- Fix internal markdown links so they resolve under the `/Awesome-Agentic-AI-Security/` base on GitHub Pages. Cross-page links emitted by `sync-content.mjs` (for example, the *landscape map* link on `/guide/threat-model/`) previously rendered as base-less absolute paths and 404'd on the deployed site.
- Strengthen the link checker to flag internal absolute paths that omit the site base, so this regression cannot return silently.
- Expand the benchmarks page with framing, criteria, a catalogue table, methodology pointers, and known limitations.
- Add an in-page chain library on `/chains/` so the "Chain library index" card has a real destination, and list every chain with a one-line description.
- Replace the *How Failures Compose* text arrow chain on `/guide/landscape-map/` with a Mermaid flowchart so the steps render as paired nodes ending at a labelled outcome.
- Replace the failure-modes mind map on `/guide/threat-model/` with an accessible Markdown table and update the surrounding prose to reference the table.

## Test plan

- [x] `npm run build` in `site/` completes without errors.
- [x] `node site/scripts/check-links.mjs` reports `OK` with the strengthened checker.
- [x] Local preview: every internal link from the benchmarks page returns HTTP 200; the *landscape map* link on the threat model page resolves; chain library cards link to each chain page.
- [ ] Reviewer to spot-check the live deploy after merge.