### PR TITLE
feat: add TWZRD Agent Intel to Credentials, Identity, and Delegated Authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ fuller model is in [Defence Architecture](docs/04-defence-architecture.md).
 - [Lakera: From Access Control to Outcome Control](https://www.lakera.ai/blog/from-access-control-to-outcome-control-securing-ai-agents-with-check-point-and-google-cloud)
   - Vendor analysis that separates valid access from acceptable outcomes in
   agentic systems.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring and
+  signed trust receipts for AI agent wallets on Solana. MCP tools
+  (`score_agent`, `preflight_check`) allow agents to verify counterparty
+  wallet reputation before executing high-value actions. Addresses the
+  non-human identity gap: wallet reputation as trust anchor for autonomous
+  agent-to-agent authorization, with x402 micropayment-gated signed receipts
+  for audit trail. Config: `{"mcpServers": {"twzrd-agent-intel": {"url":
+  "https://intel.twzrd.xyz/mcp"}}}`.
 
 ## Benchmarks and Evaluations
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Credentials, Identity, and Delegated Authority** section.

**The gap this fills**: The existing section covers human-centric identity patterns (delegated authority, token scoping, AI gateways). TWZRD fills the *non-human wallet identity* angle — for multi-agent autonomous systems where each agent has a Solana wallet address, and wallet reputation is the practical trust anchor for A2A authorization.

**What it provides**:
- `score_agent(wallet)` — on-chain trust score, behavioral risk flags, transaction history analysis
- `preflight_check(wallet)` — binary go/no-go authorization for agent-to-agent actions
- `get_trust_receipt(wallet)` — signed, on-chain-verifiable trust receipt (via x402 micropayment), providing an immutable audit record

**Attack surface addressed**: Agent impersonation — an attacker deploys a wallet claiming to be a trusted agent; `preflight_check` queries verifiable on-chain history to detect fresh/suspicious wallets before funds or authority are transferred.

**MCP Config**: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

🤖 Submitted via Claude Code