### PR TITLE
Update tools.md

### DIFF
--- a/resources/tools.md
+++ b/resources/tools.md
@@ -106,3 +106,15 @@ Each entry uses the repository metadata format: resource type, producer, source,
 - Evidence quality and maturity level: Commercial tooling with public documentation. Useful to study as an example control pattern.
 - Last checked: 2026-04-29.
 - Limitations or caveats: Product claims and effectiveness require independent validation in the target environment. Avoid relying on any single vendor control for complete agentic security.
+
+### Humanbound
+
+-Resource type: Open-source adversarial testing engine, SDK, and CLI for AI agents.
+-Producer or publisher: Humanbound project.
+-Source link: https://github.com/humanbound/humanbound.
+-Relevance to agentic execution security: Runs tests against live agent endpoints across multi-turn conversations and tool use, then converts failed tests directly into guardrail rules, a loop that open source testing tools generally leave open.
+-Coverage: Endpoint configuration tests, multi-turn conversation tests, tool-abuse test cases, and scenarios mapped to the OWASP Top 10 for Agentic Applications (prompt injection and goal hijacking listed first), plus automated guardrail rule generation, CLI, and Python SDK.
+-Evidence quality and maturity level: Open source (Apache-2.0), actively developed, earlier-stage adoption than established evaluation frameworks.
+-Last checked: 2026-07-22.
+-Limitations or caveats: Newer project with a smaller community than mature eval tools. Strongest for agent-native execution testing (endpoints, multi-turn, tool abuse); pairs well with broader prompt and response evaluation tools for full-stack coverage.
+


### PR DESCRIPTION
Adding Humanbound, an open source (Apache-2.0) adversarial testing engine for AI agents. It tests live endpoints across multi-turn conversations and tool use, then generates guardrail rules directly from what fails, closing a loop most agent testing tools leave open. CLI + Python SDK, `pip install humanbound`, docs at docs.humanbound.ai.

## Summary

Describe the change and why it belongs in this repository.

## Contribution Type

- [ ] Resource, standard, framework, or research
- [ ] Tool or benchmark
- [ ] Case study
- [ ] Secure engineering pattern or architecture
- [ ] Governance, contribution, or repository maintenance
- [ ] Other

## Evidence And Scope

- Source or evidence:
- Producer or publisher:
- Risks, behaviours, controls, or evaluation methods covered:
- Maturity or evidence level:
- Last-checked date, if external:
- Limitations or caveats:

## Review Focus

What would you like reviewers to check most closely?

## Checklist

- [ ] The change is relevant to agentic execution security.
- [ ] Claims are evidence-led and do not overstate repository maturity.
- [ ] British English is used except for established names such as AI Defense Plane.
- [ ] No unnecessary operational exploit detail is included.
- [ ] No copied source material is included when a summary and link would be enough.
- [ ] No generated outputs, built documentation, logs, traces, screenshots, reports, exports, or local artefacts are included.
- [ ] If this PR adds a new resource, case study, or benchmark, a corresponding scoresheet under `rubrics/scoresheets/` is included (see [rubrics/README.md](../rubrics/README.md)).
