### PR TITLE
Add SourceryKit to resources/tools.md

### DIFF
--- a/resources/tools.md
+++ b/resources/tools.md
@@ -140,3 +140,14 @@ Each entry uses the repository metadata format: resource type, producer, source,
 -Last checked: 2026-07-22.
 -Limitations or caveats: Newer project with a smaller community than mature eval tools. Strongest for agent-native execution testing (endpoints, multi-turn, tool abuse); pairs well with broader prompt and response evaluation tools for full-stack coverage.
 
+
+### SourceryKit
+
+- Resource type: Source-available Python SDK for verifying an agent's outbound requests at runtime.
+- Producer or publisher: Provably.
+- Source link: <https://github.com/ProvablyAI/sourcerykit>.
+- Relevance to agentic execution security: Checks an agent's outbound HTTP requests and MCP handoffs against a source of truth before they leave, using a zero-knowledge proof so a call only goes out if the agent's claims about it hold, which targets truthful-looking but tampered actions that a destination allow-list alone does not catch.
+- Coverage: Outbound request and MCP tool-call verification against a source of truth, a zero-knowledge proof of the claims, trusted-endpoint allow-listing, blocking of non-allowlisted or unverified calls, and logging of every outbound call for audit. Hooks the HTTP libraries the agent already uses.
+- Evidence quality and maturity level: Early-stage, source-available under BSL 1.1 (not an OSI open-source licence); published on PyPI as `sourcerykit`. Suitable for evaluation; independent benchmarking still maturing.
+- Last checked: 2026-07-27.
+- Limitations or caveats: Not fully offline - the zero-knowledge proof and source-of-truth check run against a backend/API, so it pairs a source-available SDK with a hosted service rather than running entirely locally. It is a per-request verification and egress control, not a complete governance stack, and someone has to define the source of truth for each flow it protects.


### PR DESCRIPTION
Adds **SourceryKit** to `resources/tools.md` using the repository metadata format (resource type, producer, source, relevance, coverage, maturity, last checked, limitations), with the licence and backend requirement noted honestly. Placed with the runtime controls near Adrian and Armorer Guard.

SourceryKit is a source-available (BSL 1.1) Python SDK that verifies an agent's outbound requests and MCP handoffs against a source of truth using a zero-knowledge proof, so a call only goes out if the agent's claims check out. It hooks the HTTP libraries the agent uses, logs every outbound call, and blocks any endpoint not on the trusted allow-list.

Disclosure: I work with Provably, the maintainers of SourceryKit. I noted the honest limitations, that it is source-available under BSL 1.1 rather than an OSI licence, and that the proof and source-of-truth check run against a backend so it is not fully offline. If you would prefer this go through an issue-template suggestion first per CONTRIBUTING, happy to do that instead.
