### PR TITLE
Add Darkmoon (GPL-3.0 autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ fuller model is in [Defence Architecture](docs/04-defence-architecture.md).
 - [Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection](https://arxiv.org/abs/2302.12173)
   - Foundational research on external content influencing LLM-integrated
   applications.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes, orchestrating offensive tools as an MCP host with proof of exploitation and a local privacy gateway.
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo) - Benchmark and
   evaluation environment for indirect prompt injection and defences in
   tool-using agents.


### PR DESCRIPTION
Hi, and thanks for maintaining this list.

We would like to add Darkmoon, a GPL-3.0 autonomous AI penetration testing platform. It covers web, API, Active Directory and Kubernetes, and it runs as an MCP host orchestrating offensive tools. A local privacy gateway keeps target data (real IPs, hostnames, credentials) away from the LLM. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: this is our project. Happy to adjust the wording or placement, or to close this if it is not a fit.