### PR TITLE
Add Bounded Agents (delegation security / APC) to papers

### DIFF
--- a/resources/papers.md
+++ b/resources/papers.md
@@ -118,4 +118,15 @@ Each entry uses the repository metadata format: resource type, producer, source,
 - Last checked: 2026-07-24.
 - Limitations or caveats: Reported performance is based on the paper's experimental settings. Real-world effectiveness depends on deployment context, communication topology, threat model fit, and operational integration with runtime controls.
 
+### Bounded Agents: Delegation Security For Multi-Agent AI Systems
+
+- Resource type: Academic paper and reference implementation.
+- Producer or publisher: Xabier Muruaga.
+- Source link: <https://arxiv.org/abs/2608.15888>.
+- Relevance to agentic execution security: Proposes the Agentic Principal Chain (APC), an authorisation architecture enforced outside the model that carries delegated authority through multi-agent chains, narrowing scope and budgets at every hop and evaluating proposed actions against accumulated session state rather than in isolation.
+- Coverage: Delegated authority, multi-agent delegation chains, composition closure, blast radius containment, intent binding, and compromised-model evaluation.
+- Evidence quality and maturity level: Emerging research with an open reference implementation and an evaluation of 3,154 instances across AgentDojo, InjecAgent, ASB, delegation-chain scenarios, and adaptive attacks.
+- Last checked: 2026-08-22.
+- Limitations or caveats: Composition Soundness depends on a complete restriction set and serialised admission. APC does not cover parameter-level validation, cross-session composition tracking, or production hardening.
+
 <!-- markdownlint-enable MD013 -->

--- a/rubrics/scoresheets/resource-bounded-agents.md
+++ b/rubrics/scoresheets/resource-bounded-agents.md
@@ -16,11 +16,11 @@ rater_count: 1
 <!-- markdownlint-disable MD013 -->
 |Criterion|Score (0-3)|Evidence|Notes|
 |---|---|---|---|
-|Relevance to agentic AI security|3|The paper centres on delegated authority, multi-agent chains, tool actions, session state, and composition closure.|Strong fit for credentials, identity, delegated authority, and runtime enforcement.|
-|Evidence-based claims|3|The methodology reports 3,154 evaluation instances across public benchmarks, live-agent runs, delegation-chain scenarios, and adaptive attacks; code, result files, and verification scripts are public.|Quantitative claims are tied to named cohorts and reproducible artefacts.|
-|Clarity and editorial quality|2|The paper defines the APC model, six-condition predicate, threat model, formal results, evaluation protocol, and guarantee tiers in separate sections.|Precise and structured, although the density of notation raises the entry cost for non-specialist readers.|
-|Recency and ongoing relevance|3|Published in 2026 with a public reference implementation and evaluation artefacts; checked on 2026-08-22.|Current and directly aligned with multi-agent delegation risks.|
-|Transparency of limitations|3|The scope and limitations sections identify policy completeness, serialised admission, static restrictions, per-session state, parameter-level validation, and production hardening boundaries.|Limitations are specific and connected to the formal guarantees and evaluation scope.|
+|Relevance to agentic AI security|3|Paper §§1 and 3–5 define the delegated-authority problem, multi-agent threat model, session-scoped authorisation model, composition constraints, and external PEP/PDP enforcement architecture.|Strong fit for credentials, identity, delegated authority, and runtime enforcement.|
+|Evidence-based claims|3|Paper §6 and §6.6's Evaluation Summary table break down 3,154 instances across InjecAgent, ASB, AgentDojo, delegation-chain scenarios, and adaptive attacks; Appendix I identifies the public code, result files, and verification scripts.|Quantitative claims are tied to named cohorts, protocols, and reproducible artefacts.|
+|Clarity and editorial quality|2|Paper §§3–6 separately define the threat model, APC abstractions, six-condition policy lifecycle, and evaluation protocol; §7.2 separates formal guarantees from empirical evidence.|Precise and structured, although the density of notation raises the entry cost for non-specialist readers.|
+|Recency and ongoing relevance|3|arXiv:2608.15888v1 was published in 2026; Appendix I links the public reference implementation and evaluation artefacts, checked on 2026-08-22.|Current and directly aligned with multi-agent delegation risks.|
+|Transparency of limitations|3|Paper §§3.5, 4.6, 7.2, and 7.4 state non-goals and assumptions covering policy completeness, serialised admission, static restrictions, per-session state, parameter-level validation, and production hardening.|Limitations are specific and connected to the formal guarantees and evaluation scope.|
 <!-- markdownlint-enable MD013 -->
 
 ## Aggregate

--- a/rubrics/scoresheets/resource-bounded-agents.md
+++ b/rubrics/scoresheets/resource-bounded-agents.md
@@ -1,0 +1,39 @@
+---
+rubric: resource-quality-rubric.md
+artefact: "Bounded Agents: Delegation Security for Multi-Agent AI Systems"
+artefact_url_or_path: https://arxiv.org/abs/2608.15888
+artefact_version: arXiv:2608.15888v1
+last_checked: 2026-08-22
+scored_by: xmuruaga
+scored_on: 2026-08-22
+rater_count: 1
+---
+
+# Resource scoresheet
+
+## Scores
+
+<!-- markdownlint-disable MD013 -->
+|Criterion|Score (0-3)|Evidence|Notes|
+|---|---|---|---|
+|Relevance to agentic AI security|3|The paper centres on delegated authority, multi-agent chains, tool actions, session state, and composition closure.|Strong fit for credentials, identity, delegated authority, and runtime enforcement.|
+|Evidence-based claims|3|The methodology reports 3,154 evaluation instances across public benchmarks, live-agent runs, delegation-chain scenarios, and adaptive attacks; code, result files, and verification scripts are public.|Quantitative claims are tied to named cohorts and reproducible artefacts.|
+|Clarity and editorial quality|2|The paper defines the APC model, six-condition predicate, threat model, formal results, evaluation protocol, and guarantee tiers in separate sections.|Precise and structured, although the density of notation raises the entry cost for non-specialist readers.|
+|Recency and ongoing relevance|3|Published in 2026 with a public reference implementation and evaluation artefacts; checked on 2026-08-22.|Current and directly aligned with multi-agent delegation risks.|
+|Transparency of limitations|3|The scope and limitations sections identify policy completeness, serialised admission, static restrictions, per-session state, parameter-level validation, and production hardening boundaries.|Limitations are specific and connected to the formal guarantees and evaluation scope.|
+<!-- markdownlint-enable MD013 -->
+
+## Aggregate
+
+- Raw total: **14 / 15**
+- Floor rule triggered: no
+- Verdict: **Include / cite from field guide**
+
+## Reviewer commentary
+
+The paper is directly relevant to delegated authority and composed outcomes in
+multi-agent systems, and it provides unusually detailed evaluation and public
+reproduction artefacts. Its guarantees remain conditional on policy
+completeness and serialised admission, while parameter-level validation,
+cross-session composition, and production hardening require complementary
+controls.


### PR DESCRIPTION
## Summary

Adds **Bounded Agents: Delegation Security for Multi-Agent AI Systems** to the papers catalogue. The paper proposes the Agentic Principal Chain (APC), an external authorisation layer for attenuating delegated scope and budgets across multi-agent chains and enforcing composition restrictions over session history.

The change also includes the resource-quality scoresheet required for new resources. It records the paper's evidence base and explicit boundaries around restriction-set completeness, serialised admission, parameter-level validation, cross-session tracking, and production hardening.

## Contribution Type

- [x] Resource, standard, framework, or research
- [ ] Tool or benchmark
- [ ] Case study
- [ ] Secure engineering pattern or architecture
- [ ] Governance, contribution, or repository maintenance
- [ ] Other

## Evidence And Scope

- Source or evidence: https://arxiv.org/abs/2608.15888 and https://github.com/xmuruaga/bounded-agents
- Producer or publisher: Xabier Muruaga
- Risks, behaviours, controls, or evaluation methods covered: delegated authority, multi-agent chains, composition closure, blast-radius containment, intent binding, and compromised-model evaluation
- Maturity or evidence level: emerging research with an open reference implementation and 3,154 evaluation instances
- Last-checked date, if external: 2026-08-22
- Limitations or caveats: guarantees depend on a complete restriction set and serialised admission; parameter-level validation, cross-session composition, and production hardening remain outside scope

## Review Focus

Please check the placement in the papers catalogue and whether the limitations are scoped clearly enough.

## Checklist

- [x] The change is relevant to agentic execution security.
- [x] Claims are evidence-led and do not overstate repository maturity.
- [x] British English is used except for established names such as AI Defense Plane.
- [x] No unnecessary operational exploit detail is included.
- [x] No copied source material is included when a summary and link would be enough.
- [x] No generated outputs, built documentation, logs, traces, screenshots, reports, exports, or local artefacts are included.
- [x] A corresponding scoresheet under `rubrics/scoresheets/` is included.

## Validation

- `markdownlint` on both changed Markdown files
- `markdown-link-check` on both changed Markdown files
- `mkdocs build`