### PR TITLE
Add HOL Guard under Tool Use, MCP, and Runtime Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ fuller model is in [Defence Architecture](docs/04-defence-architecture.md).
 - [Secure Agent Runtime](patterns/secure-agent-runtime.md) - Pattern for
   sandboxing, isolation, policy enforcement, and observability inside the
   execution loop.
+- [HOL Guard](https://github.com/hashgraph-online/hol-guard) - Local-first runtime control for AI coding agents (shell, secret-file reads, MCP server change, plugin/skill install). Not a complete prompt-injection preventer. Apache-2.0. [docs](https://hol.org/guard)
 - [OWASP Agentic Skills Top 10](https://owasp.org/www-project-agentic-skills-top-10/)
   - Emerging guidance for the security of reusable agent skills and extension
   ecosystems.


### PR DESCRIPTION
Add HOL Guard under Tool Use, MCP, and Runtime Security (after Secure Agent Runtime pattern).

HOL Guard is local-first runtime control for AI coding agents (shell, secret-file reads, MCP server change, plugin/skill install). Not a complete prompt-injection preventer. Apache-2.0.

Docs: https://hol.org/guard
Repo: https://github.com/hashgraph-online/hol-guard

Disclosure: I am a founder of Hashgraph Online / HOL Guard.