### PR TITLE
Add TraceFold entry to resources/tools.md

### DIFF
--- a/resources/tools.md
+++ b/resources/tools.md
@@ -140,3 +140,14 @@ Each entry uses the repository metadata format: resource type, producer, source,
 -Last checked: 2026-07-22.
 -Limitations or caveats: Newer project with a smaller community than mature eval tools. Strongest for agent-native execution testing (endpoints, multi-turn, tool abuse); pairs well with broader prompt and response evaluation tools for full-stack coverage.
 
+### TraceFold
+
+- Resource type: Open-source verified transformation calculus and undo engine for AI agent tool executions and filesystem mutations, written in Rust.
+- Producer or publisher: TraceFold project (independent, single maintainer).
+- Source link: <https://github.com/TraceFold/tracefold>.
+- Relevance to agentic execution security: Escrows a verified pre-commit inverse for an agent's proposed effect (filesystem write, MCP tool call) before the effect lands, or refuses the effect if no inverse can be verified, giving a governance layer a checkpoint before an irreversible action executes.
+- Coverage: Pre-commit inverse verification, effect escrow, MCP tool-call and filesystem mutation coverage, signed offline-verifiable DSSE receipts, Merkle tile logs for tamper-evident audit trails.
+- Evidence quality and maturity level: Early-stage open-source project (v0.1.1-alpha), Apache-2.0 licence, single maintainer, 14 GitHub stars as of September 2026. CI is not currently reporting a status badge; the README discloses this rather than showing an unearned status.
+- Last checked: 2026-09-01.
+- Limitations or caveats: Alpha software; APIs and receipt formats may still change. Coverage of effect types (which mutations have verified inverses) is partial and documented in the repository's own limits file rather than implied by this entry. Addresses the escrow and verification-before-commit step specifically, not policy definition, approval routing, or credential isolation.
+


### PR DESCRIPTION
### Summary

Adds one entry for [TraceFold](https://github.com/TraceFold/tracefold) to resources/tools.md, at the bottom of the Entries section (after Humanbound), following the existing 8-field metadata format used by neighbouring entries (PyRIT, Armorer Guard, Adrian, etc.).

TraceFold is a Rust engine that escrows a verified pre-commit inverse before an agent's tool effect (filesystem mutation or MCP call) lands, or refuses the effect if no inverse can be verified, and issues signed offline-verifiable receipts. It sits at the constrain/audit layer this list's scope covers under the AI Defense Plane (Protect).

### Evidence and status, written into the entry itself

Per the entry's own "Evidence quality and maturity level" and "Limitations or caveats" fields: this is alpha software (v0.1.1-alpha), Apache-2.0, single maintainer, 14 GitHub stars as of Sep 2026, and effect-type coverage (which mutations have a verified inverse) is partial and documented in the repository's own limits file rather than implied by this entry. No ranking, adoption, or performance claims are made.

Only resources/tools.md is touched - README.md, CONTRIBUTING.md, and the taxonomy docs are untouched per the repo's stated editing rules.
